### PR TITLE
build: remove deprecated Node 10 version from CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 matrix:
   include:
-    - node_js: 10
     - node_js: 12
+    - node_js: 14
 
 before_install:
   - npm install -g npm@7


### PR DESCRIPTION
## PR summary
Node 10 is deprecated, so we want to update the build to use the latest stable versions of Node, 12 and 14.