### PR TITLE
fix: bump node core version to 2.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,9 +1413,9 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
     },
     "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -4181,9 +4181,9 @@
       "dev": true
     },
     "ibm-cloud-sdk-core": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.11.3.tgz",
-      "integrity": "sha512-Ci29mQLZuFmO1305zT8MH0Frd5PoUxfD0o5bna2lhf6WIEpETMXmr6fsmsd1k/Gj2dxJ2icYxMf99q4jSuTsgA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.12.2.tgz",
+      "integrity": "sha512-56OPXZMv7k9GHSJq/MA+ovBtklAmUdPhRs7G28WvKL6lbey/7tKhU4TDUQlr3HBBB275+aDoKrY6bkbcm4FExw==",
       "requires": {
         "@types/file-type": "~5.2.1",
         "@types/isstream": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@types/node": "^12.0.8",
     "extend": "^3.0.2",
-    "ibm-cloud-sdk-core": "^2.11.3"
+    "ibm-cloud-sdk-core": "^2.12.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",


### PR DESCRIPTION
## PR summary
This PR bumps the node core version to 2.12.2 to pull in the ContainerAuthenticator functionality.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->