### PR TITLE
feat(IAM Policy Management): add support for v2/policies

### DIFF
--- a/examples/iam-policy-management.v1.test.js
+++ b/examples/iam-policy-management.v1.test.js
@@ -327,6 +327,260 @@ describe('IamPolicyManagementV1', () => {
 
     // end-delete_policy
   });
+  test('v2CreatePolicy request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2CreatePolicy() result:');
+    // begin-v2_create_policy
+
+    const policySubject = {
+      attributes: [
+        {
+          key: 'iam_id',
+          operator: 'stringEquals',
+          value: exampleUserId,
+        },
+      ],
+    };
+    const policyResourceAccountAttribute = {
+      key: 'accountId',
+      value: exampleAccountId,
+      operator: 'stringEquals',
+    };
+    const policyResourceServiceAttribute = {
+      key: 'serviceType',
+      operator: 'stringEquals',
+      value: 'service',
+    };
+    const policyResource = {
+      attributes: [policyResourceAccountAttribute, policyResourceServiceAttribute]
+    };
+    const policyControl = {
+      grant: {
+        roles: [{
+          role_id: 'crn:v1:bluemix:public:iam::::role:Viewer',
+        }],
+      }
+    };
+    const policyRule = {
+      operator: 'and',
+      conditions: [
+          {
+              key: '{{environment.attributes.day_of_week}}',
+              operator: 'dayOfWeekAnyOf',
+              value: [1, 2, 3, 4, 5],
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeGreaterThanOrEquals',
+              value: '09:00:00+00:00',
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeLessThanOrEquals',
+              value: '17:00:00+00:00',
+          },
+      ],
+    }
+    const policyPattern = 'time-based-restrictions:weekly'
+    const params = {
+      type: 'access',
+      subject: policySubject,
+      control: policyControl,
+      resource: policyResource,
+      rule: policyRule,
+      pattern: policyPattern,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2CreatePolicy(params);
+      examplePolicyId = res.result.id;
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_create_policy
+  });
+  test('v2GetPolicy request example', async () => {
+    expect(examplePolicyId).toBeDefined();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2GetPolicy() result:');
+    // begin-v2_get_policy
+
+    const params = {
+      policyId: examplePolicyId,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2GetPolicy(params);
+      examplePolicyETag = res.headers.etag;
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_get_policy
+  });
+  test('v2UpdatePolicy request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+    expect(examplePolicyId).toBeDefined();
+    expect(examplePolicyETag).toBeDefined();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2UpdatePolicy() result:');
+    // begin-v2_update_policy
+
+    const policySubject = {
+      attributes: [
+        {
+          key: 'iam_id',
+          operator: 'stringEquals',
+          value: exampleUserId,
+        },
+      ],
+    };
+    const policyResourceAccountAttribute = {
+      key: 'accountId',
+      value: exampleAccountId,
+      operator: 'stringEquals',
+    };
+    const policyResourceServiceAttribute = {
+      key: 'serviceType',
+      operator: 'stringEquals',
+      value: 'service',
+    };
+    const policyResource = {
+      attributes: [policyResourceAccountAttribute, policyResourceServiceAttribute]
+    };
+    const updatedPolicyControl = {
+      grant: {
+        roles: [{
+          role_id: 'crn:v1:bluemix:public:iam::::role:Editor',
+        }],
+      }
+    };
+    const policyRule = {
+      operator: 'and',
+      conditions: [
+          {
+              key: '{{environment.attributes.day_of_week}}',
+              operator: 'dayOfWeekAnyOf',
+              value: [1, 2, 3, 4, 5],
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeGreaterThanOrEquals',
+              value: '09:00:00+00:00',
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeLessThanOrEquals',
+              value: '17:00:00+00:00',
+          },
+      ],
+    }
+    const policyPattern = 'time-based-restrictions:weekly'
+    const params = {
+      type: 'access',
+      policyId: examplePolicyId,
+      ifMatch: examplePolicyETag,
+      subject: policySubject,
+      control: updatedPolicyControl,
+      resource: policyResource,
+      rule: policyRule,
+      pattern: policyPattern,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2UpdatePolicy(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_update_policy
+  });
+  test('v2ListPolicies request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2ListPolicies() result:');
+    // begin-v2_list_policies
+
+    const params = {
+      accountId: exampleAccountId,
+      iamId: exampleUserId,
+      format: 'include_last_permit',
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2ListPolicies(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-v2_list_policies
+  });
+  test('v2DeletePolicy request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    // begin-v2_delete_policy
+
+    const params = {
+      policyId: examplePolicyId,
+    };
+
+    try {
+      await iamPolicyManagementService.v2DeletePolicy(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-v2_delete_policy
+  });
   test('createRole request example', async () => {
     expect(exampleAccountId).not.toBeNull();
 

--- a/iam-policy-management/v1.ts
+++ b/iam-policy-management/v1.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.39.0-748eb4ca-20210917-165907
+ * IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
  */
 
 import * as extend from 'extend';
@@ -24,7 +24,7 @@ import {
   Authenticator,
   BaseService,
   getAuthenticatorFromEnvironment,
-  getMissingParams,
+  validateParams,
   UserOptions,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
@@ -141,11 +141,24 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.ListPoliciesParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.PolicyList>> {
     const _params = { ...params };
-    const requiredParams = ['accountId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['accountId'];
+    const _validParams = [
+      'accountId',
+      'acceptLanguage',
+      'iamId',
+      'accessGroupId',
+      'type',
+      'serviceType',
+      'tagName',
+      'tagValue',
+      'sort',
+      'format',
+      'state',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -204,7 +217,9 @@ class IamPolicyManagementV1 extends BaseService {
    * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
    * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
    * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
-   * **`serviceName`**,  or **`resourceGroupId`** attribute and the **`accountId`** attribute.` If the subject is a
+   * **`serviceName`**, **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.`
+   * The IAM Services group (`IAM`) is a subset of account management services that includes the IAM platform services
+   * IAM Identity, IAM Access Management, IAM Users Management, IAM Groups, and future IAM services. If the subject is a
    * locked service-id, the request will fail.
    *
    * ### Authorization
@@ -222,7 +237,7 @@ class IamPolicyManagementV1 extends BaseService {
    * ### Attribute Operators
    *
    * Currently, only the `stringEquals` and the `stringMatch` operators are available. Resource attributes may support
-   * one or both operators.  For more information, see [how to assign access by using wildcards
+   * one or both operators. For more information, see [how to assign access by using wildcards
    * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
    *
    * ### Attribute Validations
@@ -256,11 +271,19 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.CreatePolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
-    const requiredParams = ['type', 'subjects', 'roles', 'resources'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['type', 'subjects', 'roles', 'resources'];
+    const _validParams = [
+      'type',
+      'subjects',
+      'roles',
+      'resources',
+      'description',
+      'acceptLanguage',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -330,7 +353,7 @@ class IamPolicyManagementV1 extends BaseService {
    * ### Attribute Operators
    *
    * Currently, only the `stringEquals` and the `stringMatch` operators are available. Resource attributes might support
-   * one or both operators.  For more information, see [how to assign access by using wildcards
+   * one or both operators. For more information, see [how to assign access by using wildcards
    * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
    *
    * ### Attribute Validations
@@ -356,11 +379,20 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.UpdatePolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
-    const requiredParams = ['policyId', 'ifMatch', 'type', 'subjects', 'roles', 'resources'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['policyId', 'ifMatch', 'type', 'subjects', 'roles', 'resources'];
+    const _validParams = [
+      'policyId',
+      'ifMatch',
+      'type',
+      'subjects',
+      'roles',
+      'resources',
+      'description',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -419,11 +451,11 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.GetPolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
-    const requiredParams = ['policyId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -462,17 +494,17 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.policyId - The policy ID.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Empty>>}
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>>}
    */
   public deletePolicy(
     params: IamPolicyManagementV1.DeletePolicyParams
-  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Empty>> {
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['policyId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -518,11 +550,11 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.PatchPolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
-    const requiredParams = ['policyId', 'ifMatch'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['policyId', 'ifMatch'];
+    const _validParams = ['policyId', 'ifMatch', 'state', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -598,6 +630,19 @@ class IamPolicyManagementV1 extends BaseService {
     params?: IamPolicyManagementV1.ListRolesParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.RoleList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = [
+      'acceptLanguage',
+      'accountId',
+      'serviceName',
+      'sourceServiceName',
+      'policyType',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'account_id': _params.accountId,
@@ -666,11 +711,20 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.CreateRoleParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.CustomRole>> {
     const _params = { ...params };
-    const requiredParams = ['displayName', 'actions', 'name', 'accountId', 'serviceName'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['displayName', 'actions', 'name', 'accountId', 'serviceName'];
+    const _validParams = [
+      'displayName',
+      'actions',
+      'name',
+      'accountId',
+      'serviceName',
+      'description',
+      'acceptLanguage',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -733,11 +787,11 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.UpdateRoleParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.CustomRole>> {
     const _params = { ...params };
-    const requiredParams = ['roleId', 'ifMatch'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['roleId', 'ifMatch'];
+    const _validParams = ['roleId', 'ifMatch', 'displayName', 'description', 'actions', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -794,11 +848,11 @@ class IamPolicyManagementV1 extends BaseService {
     params: IamPolicyManagementV1.GetRoleParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.CustomRole>> {
     const _params = { ...params };
-    const requiredParams = ['roleId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['roleId'];
+    const _validParams = ['roleId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -836,17 +890,17 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.roleId - The role ID.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Empty>>}
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>>}
    */
   public deleteRole(
     params: IamPolicyManagementV1.DeleteRoleParams
-  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Empty>> {
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['roleId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['roleId'];
+    const _validParams = ['roleId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -862,6 +916,496 @@ class IamPolicyManagementV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v2/roles/{role_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(true, sdkHeaders, {}, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+  /*************************
+   * v2Policies
+   ************************/
+
+  /**
+   * Get policies by attributes.
+   *
+   * Get policies and filter by attributes. While managing policies, you may want to retrieve policies in the account
+   * and filter by attribute values. This can be done through query parameters. Currently, only the following attributes
+   * are supported: account_id, iam_id, access_group_id, type, service_type, sort, format and state. account_id is a
+   * required query parameter. Only policies that have the specified attributes and that the caller has read access to
+   * are returned. If the caller does not have read access to any policies an empty array is returned.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.accountId - The account GUID in which the policies belong to.
+   * @param {string} [params.acceptLanguage] - Language code for translations
+   * * `default` - English
+   * * `de` -  German (Standard)
+   * * `en` - English
+   * * `es` - Spanish (Spain)
+   * * `fr` - French (Standard)
+   * * `it` - Italian (Standard)
+   * * `ja` - Japanese
+   * * `ko` - Korean
+   * * `pt-br` - Portuguese (Brazil)
+   * * `zh-cn` - Chinese (Simplified, PRC)
+   * * `zh-tw` - (Chinese, Taiwan).
+   * @param {string} [params.iamId] - Optional IAM ID used to identify the subject.
+   * @param {string} [params.accessGroupId] - Optional access group id.
+   * @param {string} [params.type] - Optional type of policy.
+   * @param {string} [params.serviceType] - Optional type of service.
+   * @param {string} [params.serviceName] - Optional name of service.
+   * @param {string} [params.serviceGroupId] - Optional ID of service group.
+   * @param {string} [params.format] - Include additional data per policy returned
+   * * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times
+   * it has done so
+   * * `display` - returns the list of all actions included in each of the policy roles and translations for all
+   * relevant fields.
+   * @param {string} [params.state] - The state of the policy.
+   * * `active` - returns active policies
+   * * `deleted` - returns non-active policies.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>>}
+   */
+  public v2ListPolicies(
+    params: IamPolicyManagementV1.V2ListPoliciesParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>> {
+    const _params = { ...params };
+    const _requiredParams = ['accountId'];
+    const _validParams = [
+      'accountId',
+      'acceptLanguage',
+      'iamId',
+      'accessGroupId',
+      'type',
+      'serviceType',
+      'serviceName',
+      'serviceGroupId',
+      'format',
+      'state',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'account_id': _params.accountId,
+      'iam_id': _params.iamId,
+      'access_group_id': _params.accessGroupId,
+      'type': _params.type,
+      'service_type': _params.serviceType,
+      'service_name': _params.serviceName,
+      'service_group_id': _params.serviceGroupId,
+      'format': _params.format,
+      'state': _params.state,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2ListPolicies'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Accept-Language': _params.acceptLanguage,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a policy.
+   *
+   * Creates a policy to grant access between a subject and a resource. Currently, there is one type of a v2/policy:
+   * **access**. A policy administrator might want to create an access policy which grants access to a user, service-id,
+   * or an access group.
+   *
+   * ### Access
+   *
+   * To create an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**, **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.`
+   * The rule field can either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`**
+   * with a combination **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field
+   * has a maximum of 2 levels of nested **`conditions`**. The operator for a rule can be used to specify a time based
+   * restriction (e.g., access only during business hours, during the Monday-Friday work week). For example, a policy
+   * can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset of
+   * account management services that includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
+   * Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.type - The policy type; either 'access' or 'authorization'.
+   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
+   * @param {string} [params.description] - Customer-defined description.
+   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
+   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
+   * @param {string} [params.pattern] - Indicates pattern of rule.
+   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {string} [params.acceptLanguage] - Language code for translations
+   * * `default` - English
+   * * `de` -  German (Standard)
+   * * `en` - English
+   * * `es` - Spanish (Spain)
+   * * `fr` - French (Standard)
+   * * `it` - Italian (Standard)
+   * * `ja` - Japanese
+   * * `ko` - Korean
+   * * `pt-br` - Portuguese (Brazil)
+   * * `zh-cn` - Chinese (Simplified, PRC)
+   * * `zh-tw` - (Chinese, Taiwan).
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2CreatePolicy(
+    params: IamPolicyManagementV1.V2CreatePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['type', 'control'];
+    const _validParams = [
+      'type',
+      'control',
+      'description',
+      'subject',
+      'resource',
+      'pattern',
+      'rule',
+      'acceptLanguage',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'type': _params.type,
+      'control': _params.control,
+      'description': _params.description,
+      'subject': _params.subject,
+      'resource': _params.resource,
+      'pattern': _params.pattern,
+      'rule': _params.rule,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2CreatePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies',
+        method: 'POST',
+        body,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Accept-Language': _params.acceptLanguage,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a policy.
+   *
+   * Update a policy to grant access between a subject and a resource. A policy administrator might want to update an
+   * existing policy.
+   *
+   * ### Access
+   *
+   * To update an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**,  or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can
+   * either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+   * **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+   * levels of nested **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g.,
+   * access only during business hours, during the Monday-Friday work week). For example, a policy can grant access
+   * Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
+   * request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {string} params.ifMatch - The revision number for updating a policy and must match the ETag value of the
+   * existing policy. The Etag can be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag
+   * response header.
+   * @param {string} params.type - The policy type; either 'access' or 'authorization'.
+   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
+   * @param {string} [params.description] - Customer-defined description.
+   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
+   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
+   * @param {string} [params.pattern] - Indicates pattern of rule.
+   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2UpdatePolicy(
+    params: IamPolicyManagementV1.V2UpdatePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId', 'ifMatch', 'type', 'control'];
+    const _validParams = [
+      'policyId',
+      'ifMatch',
+      'type',
+      'control',
+      'description',
+      'subject',
+      'resource',
+      'pattern',
+      'rule',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'type': _params.type,
+      'control': _params.control,
+      'description': _params.description,
+      'subject': _params.subject,
+      'resource': _params.resource,
+      'pattern': _params.pattern,
+      'rule': _params.rule,
+    };
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2UpdatePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
+        method: 'PUT',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a policy by ID.
+   *
+   * Retrieve a policy by providing a policy ID.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2GetPolicy(
+    params: IamPolicyManagementV1.V2GetPolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2GetPolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a policy by ID.
+   *
+   * Delete a policy by providing a policy ID. A policy cannot be deleted if the subject ID contains a locked service
+   * ID. If the subject of the policy is a locked service-id, the request will fail.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>>}
+   */
+  public v2DeletePolicy(
+    params: IamPolicyManagementV1.V2DeletePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2DeletePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
         method: 'DELETE',
         path,
       },
@@ -891,7 +1435,7 @@ namespace IamPolicyManagementV1 {
   export type Callback<T> = (error: any, response?: Response<T>) => void;
 
   /** The body of a service request that returns no response data. */
-  export interface Empty {}
+  export interface EmptyObject {}
 
   /** A standard JS object, defined to avoid the limitations of `Object` and `object` */
   export interface JsonObject {
@@ -1161,9 +1705,174 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `v2ListPolicies` operation. */
+  export interface V2ListPoliciesParams {
+    /** The account GUID in which the policies belong to. */
+    accountId: string;
+    /** Language code for translations
+     *  * `default` - English
+     *  * `de` -  German (Standard)
+     *  * `en` - English
+     *  * `es` - Spanish (Spain)
+     *  * `fr` - French (Standard)
+     *  * `it` - Italian (Standard)
+     *  * `ja` - Japanese
+     *  * `ko` - Korean
+     *  * `pt-br` - Portuguese (Brazil)
+     *  * `zh-cn` - Chinese (Simplified, PRC)
+     *  * `zh-tw` - (Chinese, Taiwan).
+     */
+    acceptLanguage?: string;
+    /** Optional IAM ID used to identify the subject. */
+    iamId?: string;
+    /** Optional access group id. */
+    accessGroupId?: string;
+    /** Optional type of policy. */
+    type?: V2ListPoliciesConstants.Type | string;
+    /** Optional type of service. */
+    serviceType?: V2ListPoliciesConstants.ServiceType | string;
+    /** Optional name of service. */
+    serviceName?: string;
+    /** Optional ID of service group. */
+    serviceGroupId?: string;
+    /** Include additional data per policy returned
+     *  * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of
+     *  times it has done so
+     *  * `display` - returns the list of all actions included in each of the policy roles and translations for all
+     *  relevant fields.
+     */
+    format?: V2ListPoliciesConstants.Format | string;
+    /** The state of the policy. * `active` - returns active policies * `deleted` - returns non-active policies. */
+    state?: V2ListPoliciesConstants.State | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `v2ListPolicies` operation. */
+  export namespace V2ListPoliciesConstants {
+    /** Optional type of policy. */
+    export enum Type {
+      ACCESS = 'access',
+      AUTHORIZATION = 'authorization',
+    }
+    /** Optional type of service. */
+    export enum ServiceType {
+      SERVICE = 'service',
+      PLATFORM_SERVICE = 'platform_service',
+    }
+    /** Include additional data per policy returned * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times it has done so * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant fields. */
+    export enum Format {
+      INCLUDE_LAST_PERMIT = 'include_last_permit',
+      DISPLAY = 'display',
+    }
+    /** The state of the policy. * `active` - returns active policies * `deleted` - returns non-active policies. */
+    export enum State {
+      ACTIVE = 'active',
+      DELETED = 'deleted',
+    }
+  }
+
+  /** Parameters for the `v2CreatePolicy` operation. */
+  export interface V2CreatePolicyParams {
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    /** Language code for translations
+     *  * `default` - English
+     *  * `de` -  German (Standard)
+     *  * `en` - English
+     *  * `es` - Spanish (Spain)
+     *  * `fr` - French (Standard)
+     *  * `it` - Italian (Standard)
+     *  * `ja` - Japanese
+     *  * `ko` - Korean
+     *  * `pt-br` - Portuguese (Brazil)
+     *  * `zh-cn` - Chinese (Simplified, PRC)
+     *  * `zh-tw` - (Chinese, Taiwan).
+     */
+    acceptLanguage?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2UpdatePolicy` operation. */
+  export interface V2UpdatePolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    /** The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can
+     *  be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag response header.
+     */
+    ifMatch: string;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2GetPolicy` operation. */
+  export interface V2GetPolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2DeletePolicy` operation. */
+  export interface V2DeletePolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /*************************
    * model interfaces
    ************************/
+
+  /** Specifies the type of access granted by the policy. */
+  export interface V2PolicyBaseControl {
+    /** Permission granted by the policy. */
+    grant: V2PolicyBaseControlGrant;
+  }
+
+  /** Permission granted by the policy. */
+  export interface V2PolicyBaseControlGrant {
+    /** A set of role cloud resource names (CRNs) granted by the policy. */
+    roles: PolicyRole[];
+  }
+
+  /** The resource attributes associated with a policy. */
+  export interface V2PolicyBaseResource {
+    /** List of resource attributes associated with policy/. */
+    attributes?: V2PolicyAttribute[];
+  }
+
+  /** Additional access conditions associated with a policy. */
+  export interface V2PolicyBaseRule {}
+
+  /** The subject attributes associated with a policy. */
+  export interface V2PolicyBaseSubject {
+    /** List of subject attributes associated with policy/. */
+    attributes?: V2PolicyAttribute[];
+  }
 
   /** An additional set of properties associated with a role. */
   export interface CustomRole {
@@ -1311,6 +2020,72 @@ namespace IamPolicyManagementV1 {
     name: string;
     /** The value of an attribute. */
     value: string;
+  }
+
+  /** The core set of properties associated with a policy. */
+  export interface V2Policy {
+    /** The policy ID. */
+    id?: string;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    /** The href link back to the policy. */
+    href?: string;
+    /** The UTC timestamp when the policy was created. */
+    created_at?: string;
+    /** The iam ID of the entity that created the policy. */
+    created_by_id?: string;
+    /** The UTC timestamp when the policy was last modified. */
+    last_modified_at?: string;
+    /** The iam ID of the entity that last modified the policy. */
+    last_modified_by_id?: string;
+    /** The policy state. */
+    state?: string;
+  }
+
+  /** Resource/subject attribute associated with policy attributes. */
+  export interface V2PolicyAttribute {
+    /** The name of an attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an attribute; can be array, boolean, string, or integer. */
+    value: any;
+  }
+
+  /** A collection of policies. */
+  export interface V2PolicyList {
+    /** List of policies. */
+    policies?: V2Policy[];
+  }
+
+  /** Resource/subject attribute associated with policy attributes. */
+  export interface V2PolicyBaseRuleV2PolicyAttribute extends V2PolicyBaseRule {
+    /** The name of an attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an attribute; can be array, boolean, string, or integer. */
+    value: any;
+  }
+
+  /** Policy rule that has 2 to 10 conditions. */
+  export interface V2PolicyBaseRuleV2RuleWithConditions extends V2PolicyBaseRule {
+    /** Operator to evalute conditions. */
+    operator: string;
+    /** List of conditions to associated with a policy. Note that conditions can be nested up to 2 levels. */
+    conditions: V2PolicyAttribute[];
   }
 }
 

--- a/test/integration/iam-policy-management.v1.test.js
+++ b/test/integration/iam-policy-management.v1.test.js
@@ -101,34 +101,34 @@ describe('IamPolicyManagementV1_integration', () => {
     value: 'service',
   };
   const v2PolicyResource = {
-    attributes: [v2PolicyResourceAccountAttribute, v2PolicyResourceServiceAttribute]
+    attributes: [v2PolicyResourceAccountAttribute, v2PolicyResourceServiceAttribute],
   };
   const v2PolicyControl = {
     grant: {
-      roles: policyRoles
-    }
+      roles: policyRoles,
+    },
   };
   const v2PolicyRule = {
     operator: 'and',
     conditions: [
-        {
-            key: '{{environment.attributes.day_of_week}}',
-            operator: 'dayOfWeekAnyOf',
-            value: [1, 2, 3, 4, 5],
-        },
-        {
-            key: '{{environment.attributes.current_time}}',
-            operator: 'timeGreaterThanOrEquals',
-            value: '09:00:00+00:00',
-        },
-        {
-            key: '{{environment.attributes.current_time}}',
-            operator: 'timeLessThanOrEquals',
-            value: '17:00:00+00:00',
-        },
+      {
+        key: '{{environment.attributes.day_of_week}}',
+        operator: 'dayOfWeekAnyOf',
+        value: [1, 2, 3, 4, 5],
+      },
+      {
+        key: '{{environment.attributes.current_time}}',
+        operator: 'timeGreaterThanOrEquals',
+        value: '09:00:00+00:00',
+      },
+      {
+        key: '{{environment.attributes.current_time}}',
+        operator: 'timeLessThanOrEquals',
+        value: '17:00:00+00:00',
+      },
     ],
-  }
-  const v2PolicyPattern = 'time-based-restrictions:weekly'
+  };
+  const v2PolicyPattern = 'time-based-restrictions:weekly';
 
   let testCustomRoleId;
   let testCustomRoleEtag;
@@ -182,7 +182,6 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.resources).toEqual(policyResources);
 
       testPolicyId = result.id;
-
     });
 
     test('Get an access policy', async () => {
@@ -388,7 +387,6 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.resource).toEqual(v2PolicyResource);
 
       testV2PolicyId = result.id;
-
     });
 
     test('Get a v2 access policy', async () => {
@@ -428,9 +426,9 @@ describe('IamPolicyManagementV1_integration', () => {
             {
               role_id: testEditorRoleCrn,
             },
-          ]
-        }
-      }
+          ],
+        },
+      };
 
       const params = {
         policyId: testV2PolicyId,

--- a/test/integration/iam-policy-management.v1.test.js
+++ b/test/integration/iam-policy-management.v1.test.js
@@ -36,6 +36,8 @@ describe('IamPolicyManagementV1_integration', () => {
   let testAccountId;
   let testPolicyETag;
   let testPolicyId;
+  let testV2PolicyETag;
+  let testV2PolicyId;
   const testUniqueId = Math.floor(Math.random() * 100000);
   const testUserId = `IBMid-SDKNode${testUniqueId}`;
   const testViewerRoleCrn = 'crn:v1:bluemix:public:iam::::role:Viewer';
@@ -79,6 +81,55 @@ describe('IamPolicyManagementV1_integration', () => {
     },
   ];
 
+  const v2PolicySubject = {
+    attributes: [
+      {
+        key: 'iam_id',
+        operator: 'stringEquals',
+        value: testUserId,
+      },
+    ],
+  };
+  const v2PolicyResourceAccountAttribute = {
+    key: 'accountId',
+    value: testAccountId,
+    operator: 'stringEquals',
+  };
+  const v2PolicyResourceServiceAttribute = {
+    key: 'serviceType',
+    operator: 'stringEquals',
+    value: 'service',
+  };
+  const v2PolicyResource = {
+    attributes: [v2PolicyResourceAccountAttribute, v2PolicyResourceServiceAttribute]
+  };
+  const v2PolicyControl = {
+    grant: {
+      roles: policyRoles
+    }
+  };
+  const v2PolicyRule = {
+    operator: 'and',
+    conditions: [
+        {
+            key: '{{environment.attributes.day_of_week}}',
+            operator: 'dayOfWeekAnyOf',
+            value: [1, 2, 3, 4, 5],
+        },
+        {
+            key: '{{environment.attributes.current_time}}',
+            operator: 'timeGreaterThanOrEquals',
+            value: '09:00:00+00:00',
+        },
+        {
+            key: '{{environment.attributes.current_time}}',
+            operator: 'timeLessThanOrEquals',
+            value: '17:00:00+00:00',
+        },
+    ],
+  }
+  const v2PolicyPattern = 'time-based-restrictions:weekly'
+
   let testCustomRoleId;
   let testCustomRoleEtag;
   const testCustomRoleName = `TestNodeRole${testUniqueId}`;
@@ -106,7 +157,7 @@ describe('IamPolicyManagementV1_integration', () => {
   });
 
   describe('Access policy tests', () => {
-    test('Create an access policy', async (done) => {
+    test('Create an access policy', async () => {
       const params = {
         type: 'access',
         subjects: policySubjects,
@@ -118,7 +169,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.createPolicy(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -132,10 +183,9 @@ describe('IamPolicyManagementV1_integration', () => {
 
       testPolicyId = result.id;
 
-      done();
     });
 
-    test('Get an access policy', async (done) => {
+    test('Get an access policy', async () => {
       expect(testPolicyId).toBeDefined();
 
       const params = {
@@ -146,7 +196,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.getPolicy(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -160,11 +210,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.resources).toEqual(policyResources);
 
       testPolicyETag = response.headers.etag;
-
-      done();
     });
 
-    test('Update an access policy', async (done) => {
+    test('Update an access policy', async () => {
       expect(testPolicyId).toBeDefined();
       expect(testPolicyETag).toBeDefined();
 
@@ -187,7 +235,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.updatePolicy(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -201,11 +249,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.resources).toEqual(policyResources);
 
       testPolicyETag = response.headers.etag;
-
-      done();
     });
 
-    test('Patch an access policy', async (done) => {
+    test('Patch an access policy', async () => {
       expect(testPolicyId).toBeDefined();
       expect(testPolicyETag).toBeDefined();
 
@@ -219,7 +265,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.patchPolicy(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -231,11 +277,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.subjects).toEqual(policySubjects);
       expect(result.state).toEqual('active');
       expect(result.resources).toEqual(policyResources);
-
-      done();
     });
 
-    test('List access policies', async (done) => {
+    test('List access policies', async () => {
       expect(testPolicyId).toBeDefined();
 
       const params = {
@@ -247,7 +291,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.listPolicies(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -265,11 +309,9 @@ describe('IamPolicyManagementV1_integration', () => {
         }
       }
       expect(foundTestPolicy).toBeTruthy();
-
-      done();
     });
 
-    test('Clean up all test policies', async (done) => {
+    test('Clean up all test policies', async () => {
       // List all policies for the test user in the account
       const params = {
         accountId: testAccountId,
@@ -280,7 +322,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.listPolicies(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -305,20 +347,200 @@ describe('IamPolicyManagementV1_integration', () => {
           try {
             response = await service.deletePolicy(params);
           } catch (err) {
-            done(err);
+            console.warn(err);
           }
 
           expect(response).toBeDefined();
           expect(response.status).toEqual(204);
         }
       }
+    });
+  });
 
-      done();
+  describe('V2 Access policy tests', () => {
+    test('Create a v2 access policy', async () => {
+      const params = {
+        type: 'access',
+        subject: v2PolicySubject,
+        control: v2PolicyControl,
+        resource: v2PolicyResource,
+        rule: v2PolicyRule,
+        pattern: v2PolicyPattern,
+      };
+
+      // ensure resource account value is defined
+      v2PolicyResource.attributes[0].value = testAccountId;
+
+      let response;
+      try {
+        response = await service.v2CreatePolicy(params);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(201);
+      const { result } = response || {};
+      expect(result).toBeDefined();
+      expect(result.type).toEqual(policyType);
+      expect(result.subject).toEqual(v2PolicySubject);
+      expect(result.control).toEqual(v2PolicyControl);
+      expect(result.resource).toEqual(v2PolicyResource);
+
+      testV2PolicyId = result.id;
+
+    });
+
+    test('Get a v2 access policy', async () => {
+      expect(testPolicyId).toBeDefined();
+
+      const params = {
+        policyId: testV2PolicyId,
+      };
+
+      let response;
+      try {
+        response = await service.v2GetPolicy(params);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(200);
+      const { result } = response || {};
+      expect(result).toBeDefined();
+      expect(result.id).toEqual(testV2PolicyId);
+      expect(result.type).toEqual(policyType);
+      expect(result.subject).toEqual(v2PolicySubject);
+      expect(result.control).toEqual(v2PolicyControl);
+      expect(result.resource).toEqual(v2PolicyResource);
+
+      testV2PolicyETag = response.headers.etag;
+    });
+
+    test('Update a v2 access policy', async () => {
+      expect(testV2PolicyId).toBeDefined();
+      expect(testV2PolicyETag).toBeDefined();
+
+      const updatedControl = {
+        grant: {
+          roles: [
+            {
+              role_id: testEditorRoleCrn,
+            },
+          ]
+        }
+      }
+
+      const params = {
+        policyId: testV2PolicyId,
+        ifMatch: testV2PolicyETag,
+        type: 'access',
+        subject: v2PolicySubject,
+        control: updatedControl,
+        resource: v2PolicyResource,
+        rule: v2PolicyRule,
+        pattern: v2PolicyPattern,
+      };
+
+      let response;
+      try {
+        response = await service.v2UpdatePolicy(params);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(200);
+      const { result } = response || {};
+      expect(result).toBeDefined();
+      expect(result.id).toEqual(testV2PolicyId);
+      expect(result.type).toEqual(policyType);
+      expect(result.subject).toEqual(v2PolicySubject);
+      expect(result.control).toEqual(updatedControl);
+      expect(result.resource).toEqual(v2PolicyResource);
+    });
+
+    test('List v2 access policies', async () => {
+      expect(testPolicyId).toBeDefined();
+
+      const params = {
+        accountId: testAccountId,
+        iamId: testUserId,
+      };
+
+      let response;
+      try {
+        response = await service.v2ListPolicies(params);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(200);
+      const { result } = response || {};
+      expect(result).toBeDefined();
+
+      // Confirm the test policy is present
+      let foundTestPolicy = false;
+      let policy;
+      for (policy of result.policies) {
+        if (policy.id === testV2PolicyId) {
+          foundTestPolicy = true;
+          break;
+        }
+      }
+      expect(foundTestPolicy).toBeTruthy();
+    });
+
+    test('Clean up all v2 test policies', async () => {
+      // List all policies for the test user in the account
+      const params = {
+        accountId: testAccountId,
+        iamId: testUserId,
+      };
+
+      let response;
+      try {
+        response = await service.v2ListPolicies(params);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      expect(response).toBeDefined();
+      expect(response.status).toEqual(200);
+      const { result } = response || {};
+      expect(result).toBeDefined();
+
+      // Iterate across the policies
+      let policy;
+      for (policy of result.policies) {
+        // Delete the test policy (or any test policies older than 5 minutes)
+        const createdAt = Date.parse(policy.created_at);
+        const FIVE_MINUTES = 5 * 60 * 1000;
+        const fiveMinutesAgo = Date.now() - FIVE_MINUTES;
+
+        if (policy.id === testV2PolicyId || createdAt < fiveMinutesAgo) {
+          const params = {
+            policyId: policy.id,
+          };
+
+          let response;
+          try {
+            response = await service.v2DeletePolicy(params);
+          } catch (err) {
+            console.warn(err);
+          }
+
+          expect(response).toBeDefined();
+          expect(response.status).toEqual(204);
+        }
+      }
     });
   });
 
   describe('Custom roles tests', () => {
-    test('Create a custom role', async (done) => {
+    test('Create a custom role', async () => {
       const params = {
         displayName: testCustomRoleDisplayName,
         description: testCustomRoleDescription,
@@ -332,7 +554,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.createRole(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -347,11 +569,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.actions).toEqual(testCustomRoleActions);
 
       testCustomRoleId = result.id;
-
-      done();
     });
 
-    test('Get a custom role', async (done) => {
+    test('Get a custom role', async () => {
       expect(testCustomRoleId).toBeDefined();
 
       const params = {
@@ -362,7 +582,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.getRole(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -378,11 +598,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.actions).toEqual(testCustomRoleActions);
 
       testCustomRoleEtag = response.headers.etag;
-
-      done();
     });
 
-    test('Update a custom role', async (done) => {
+    test('Update a custom role', async () => {
       expect(testCustomRoleId).toBeDefined();
       expect(testCustomRoleEtag).toBeDefined();
 
@@ -399,7 +617,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.updateRole(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -413,11 +631,9 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.account_id).toEqual(testAccountId);
       expect(result.service_name).toEqual(testServiceName);
       expect(result.actions).toEqual(testCustomRoleActions);
-
-      done();
     });
 
-    test('List custom roles', async (done) => {
+    test('List custom roles', async () => {
       expect(testCustomRoleId).toBeDefined();
 
       const params = {
@@ -429,7 +645,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.listRoles(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -447,11 +663,9 @@ describe('IamPolicyManagementV1_integration', () => {
         }
       }
       expect(foundCustomRole).toBeTruthy();
-
-      done();
     });
 
-    test('Clean up all test custom roles', async (done) => {
+    test('Clean up all test custom roles', async () => {
       // List all custom roles in the account
       const params = {
         accountId: testAccountId,
@@ -462,7 +676,7 @@ describe('IamPolicyManagementV1_integration', () => {
       try {
         response = await service.listRoles(params);
       } catch (err) {
-        done(err);
+        console.warn(err);
       }
 
       expect(response).toBeDefined();
@@ -487,15 +701,13 @@ describe('IamPolicyManagementV1_integration', () => {
           try {
             response = await service.deleteRole(params);
           } catch (err) {
-            done(err);
+            console.warn(err);
           }
 
           expect(response).toBeDefined();
           expect(response.status).toEqual(204);
         }
       }
-
-      done();
     });
   });
 });

--- a/test/unit/iam-policy-management.v1.test.js
+++ b/test/unit/iam-policy-management.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,20 +37,31 @@ const iamPolicyManagementServiceOptions = {
 
 const iamPolicyManagementService = new IamPolicyManagementV1(iamPolicyManagementServiceOptions);
 
-// dont actually create a request
-const createRequestMock = jest.spyOn(iamPolicyManagementService, 'createRequest');
-createRequestMock.mockImplementation(() => Promise.resolve());
+let createRequestMock = null;
+function mock_createRequest() {
+  if (!createRequestMock) {
+    createRequestMock = jest.spyOn(iamPolicyManagementService, 'createRequest');
+    createRequestMock.mockImplementation(() => Promise.resolve());
+  }
+}
 
 // dont actually construct an authenticator
 const getAuthenticatorMock = jest.spyOn(core, 'getAuthenticatorFromEnvironment');
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
 
-afterEach(() => {
-  createRequestMock.mockClear();
-  getAuthenticatorMock.mockClear();
-});
-
 describe('IamPolicyManagementV1', () => {
+
+  beforeEach(() => {
+    mock_createRequest();
+  });
+
+  afterEach(() => {
+    if (createRequestMock) {
+      createRequestMock.mockClear();
+    }
+    getAuthenticatorMock.mockClear();
+  });
+  
   describe('the newInstance method', () => {
     test('should use defaults when options not provided', () => {
       const testInstance = IamPolicyManagementV1.newInstance();
@@ -78,6 +89,7 @@ describe('IamPolicyManagementV1', () => {
       expect(testInstance).toBeInstanceOf(IamPolicyManagementV1);
     });
   });
+
   describe('the constructor', () => {
     test('use user-given service url', () => {
       const options = {
@@ -100,6 +112,7 @@ describe('IamPolicyManagementV1', () => {
       expect(testInstance.baseOptions.serviceUrl).toBe(IamPolicyManagementV1.DEFAULT_SERVICE_URL);
     });
   });
+
   describe('listPolicies', () => {
     describe('positive tests', () => {
       function __listPoliciesTest() {
@@ -115,21 +128,21 @@ describe('IamPolicyManagementV1', () => {
         const sort = 'id';
         const format = 'include_last_permit';
         const state = 'active';
-        const params = {
-          accountId: accountId,
-          acceptLanguage: acceptLanguage,
-          iamId: iamId,
-          accessGroupId: accessGroupId,
-          type: type,
-          serviceType: serviceType,
-          tagName: tagName,
-          tagValue: tagValue,
-          sort: sort,
-          format: format,
-          state: state,
+        const listPoliciesParams = {
+          accountId,
+          acceptLanguage,
+          iamId,
+          accessGroupId,
+          type,
+          serviceType,
+          tagName,
+          tagValue,
+          sort,
+          format,
+          state,
         };
 
-        const listPoliciesResult = iamPolicyManagementService.listPolicies(params);
+        const listPoliciesResult = iamPolicyManagementService.listPolicies(listPoliciesParams);
 
         // all methods should return a Promise
         expectToBePromise(listPoliciesResult);
@@ -176,7 +189,7 @@ describe('IamPolicyManagementV1', () => {
         const accountId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listPoliciesParams = {
           accountId,
           headers: {
             Accept: userAccept,
@@ -184,7 +197,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.listPolicies(params);
+        iamPolicyManagementService.listPolicies(listPoliciesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -213,6 +226,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('createPolicy', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -261,16 +275,16 @@ describe('IamPolicyManagementV1', () => {
         const resources = [policyResourceModel];
         const description = 'testString';
         const acceptLanguage = 'default';
-        const params = {
-          type: type,
-          subjects: subjects,
-          roles: roles,
-          resources: resources,
-          description: description,
-          acceptLanguage: acceptLanguage,
+        const createPolicyParams = {
+          type,
+          subjects,
+          roles,
+          resources,
+          description,
+          acceptLanguage,
         };
 
-        const createPolicyResult = iamPolicyManagementService.createPolicy(params);
+        const createPolicyResult = iamPolicyManagementService.createPolicy(createPolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(createPolicyResult);
@@ -315,7 +329,7 @@ describe('IamPolicyManagementV1', () => {
         const resources = [policyResourceModel];
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createPolicyParams = {
           type,
           subjects,
           roles,
@@ -326,7 +340,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.createPolicy(params);
+        iamPolicyManagementService.createPolicy(createPolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -355,6 +369,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('updatePolicy', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -404,17 +419,17 @@ describe('IamPolicyManagementV1', () => {
         const roles = [policyRoleModel];
         const resources = [policyResourceModel];
         const description = 'testString';
-        const params = {
-          policyId: policyId,
-          ifMatch: ifMatch,
-          type: type,
-          subjects: subjects,
-          roles: roles,
-          resources: resources,
-          description: description,
+        const updatePolicyParams = {
+          policyId,
+          ifMatch,
+          type,
+          subjects,
+          roles,
+          resources,
+          description,
         };
 
-        const updatePolicyResult = iamPolicyManagementService.updatePolicy(params);
+        const updatePolicyResult = iamPolicyManagementService.updatePolicy(updatePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(updatePolicyResult);
@@ -462,7 +477,7 @@ describe('IamPolicyManagementV1', () => {
         const resources = [policyResourceModel];
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updatePolicyParams = {
           policyId,
           ifMatch,
           type,
@@ -475,7 +490,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.updatePolicy(params);
+        iamPolicyManagementService.updatePolicy(updatePolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -504,16 +519,17 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('getPolicy', () => {
     describe('positive tests', () => {
       function __getPolicyTest() {
         // Construct the params object for operation getPolicy
         const policyId = 'testString';
-        const params = {
-          policyId: policyId,
+        const getPolicyParams = {
+          policyId,
         };
 
-        const getPolicyResult = iamPolicyManagementService.getPolicy(params);
+        const getPolicyResult = iamPolicyManagementService.getPolicy(getPolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(getPolicyResult);
@@ -550,7 +566,7 @@ describe('IamPolicyManagementV1', () => {
         const policyId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getPolicyParams = {
           policyId,
           headers: {
             Accept: userAccept,
@@ -558,7 +574,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.getPolicy(params);
+        iamPolicyManagementService.getPolicy(getPolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -587,16 +603,17 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('deletePolicy', () => {
     describe('positive tests', () => {
       function __deletePolicyTest() {
         // Construct the params object for operation deletePolicy
         const policyId = 'testString';
-        const params = {
-          policyId: policyId,
+        const deletePolicyParams = {
+          policyId,
         };
 
-        const deletePolicyResult = iamPolicyManagementService.deletePolicy(params);
+        const deletePolicyResult = iamPolicyManagementService.deletePolicy(deletePolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(deletePolicyResult);
@@ -633,7 +650,7 @@ describe('IamPolicyManagementV1', () => {
         const policyId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deletePolicyParams = {
           policyId,
           headers: {
             Accept: userAccept,
@@ -641,7 +658,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.deletePolicy(params);
+        iamPolicyManagementService.deletePolicy(deletePolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -670,6 +687,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('patchPolicy', () => {
     describe('positive tests', () => {
       function __patchPolicyTest() {
@@ -677,13 +695,13 @@ describe('IamPolicyManagementV1', () => {
         const policyId = 'testString';
         const ifMatch = 'testString';
         const state = 'active';
-        const params = {
-          policyId: policyId,
-          ifMatch: ifMatch,
-          state: state,
+        const patchPolicyParams = {
+          policyId,
+          ifMatch,
+          state,
         };
 
-        const patchPolicyResult = iamPolicyManagementService.patchPolicy(params);
+        const patchPolicyResult = iamPolicyManagementService.patchPolicy(patchPolicyParams);
 
         // all methods should return a Promise
         expectToBePromise(patchPolicyResult);
@@ -723,7 +741,7 @@ describe('IamPolicyManagementV1', () => {
         const ifMatch = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const patchPolicyParams = {
           policyId,
           ifMatch,
           headers: {
@@ -732,7 +750,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.patchPolicy(params);
+        iamPolicyManagementService.patchPolicy(patchPolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -761,6 +779,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('listRoles', () => {
     describe('positive tests', () => {
       function __listRolesTest() {
@@ -770,15 +789,15 @@ describe('IamPolicyManagementV1', () => {
         const serviceName = 'iam-groups';
         const sourceServiceName = 'iam-groups';
         const policyType = 'authorization';
-        const params = {
-          acceptLanguage: acceptLanguage,
-          accountId: accountId,
-          serviceName: serviceName,
-          sourceServiceName: sourceServiceName,
-          policyType: policyType,
+        const listRolesParams = {
+          acceptLanguage,
+          accountId,
+          serviceName,
+          sourceServiceName,
+          policyType,
         };
 
-        const listRolesResult = iamPolicyManagementService.listRoles(params);
+        const listRolesResult = iamPolicyManagementService.listRoles(listRolesParams);
 
         // all methods should return a Promise
         expectToBePromise(listRolesResult);
@@ -818,14 +837,14 @@ describe('IamPolicyManagementV1', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listRolesParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.listRoles(params);
+        iamPolicyManagementService.listRoles(listRolesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -836,6 +855,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('createRole', () => {
     describe('positive tests', () => {
       function __createRoleTest() {
@@ -847,17 +867,17 @@ describe('IamPolicyManagementV1', () => {
         const serviceName = 'iam-groups';
         const description = 'testString';
         const acceptLanguage = 'default';
-        const params = {
-          displayName: displayName,
-          actions: actions,
-          name: name,
-          accountId: accountId,
-          serviceName: serviceName,
-          description: description,
-          acceptLanguage: acceptLanguage,
+        const createRoleParams = {
+          displayName,
+          actions,
+          name,
+          accountId,
+          serviceName,
+          description,
+          acceptLanguage,
         };
 
-        const createRoleResult = iamPolicyManagementService.createRole(params);
+        const createRoleResult = iamPolicyManagementService.createRole(createRoleParams);
 
         // all methods should return a Promise
         expectToBePromise(createRoleResult);
@@ -904,7 +924,7 @@ describe('IamPolicyManagementV1', () => {
         const serviceName = 'iam-groups';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createRoleParams = {
           displayName,
           actions,
           name,
@@ -916,7 +936,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.createRole(params);
+        iamPolicyManagementService.createRole(createRoleParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -945,6 +965,7 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('updateRole', () => {
     describe('positive tests', () => {
       function __updateRoleTest() {
@@ -954,15 +975,15 @@ describe('IamPolicyManagementV1', () => {
         const displayName = 'testString';
         const description = 'testString';
         const actions = ['testString'];
-        const params = {
-          roleId: roleId,
-          ifMatch: ifMatch,
-          displayName: displayName,
-          description: description,
-          actions: actions,
+        const updateRoleParams = {
+          roleId,
+          ifMatch,
+          displayName,
+          description,
+          actions,
         };
 
-        const updateRoleResult = iamPolicyManagementService.updateRole(params);
+        const updateRoleResult = iamPolicyManagementService.updateRole(updateRoleParams);
 
         // all methods should return a Promise
         expectToBePromise(updateRoleResult);
@@ -1004,7 +1025,7 @@ describe('IamPolicyManagementV1', () => {
         const ifMatch = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updateRoleParams = {
           roleId,
           ifMatch,
           headers: {
@@ -1013,7 +1034,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.updateRole(params);
+        iamPolicyManagementService.updateRole(updateRoleParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1042,16 +1063,17 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('getRole', () => {
     describe('positive tests', () => {
       function __getRoleTest() {
         // Construct the params object for operation getRole
         const roleId = 'testString';
-        const params = {
-          roleId: roleId,
+        const getRoleParams = {
+          roleId,
         };
 
-        const getRoleResult = iamPolicyManagementService.getRole(params);
+        const getRoleResult = iamPolicyManagementService.getRole(getRoleParams);
 
         // all methods should return a Promise
         expectToBePromise(getRoleResult);
@@ -1088,7 +1110,7 @@ describe('IamPolicyManagementV1', () => {
         const roleId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getRoleParams = {
           roleId,
           headers: {
             Accept: userAccept,
@@ -1096,7 +1118,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.getRole(params);
+        iamPolicyManagementService.getRole(getRoleParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1125,16 +1147,17 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
   describe('deleteRole', () => {
     describe('positive tests', () => {
       function __deleteRoleTest() {
         // Construct the params object for operation deleteRole
         const roleId = 'testString';
-        const params = {
-          roleId: roleId,
+        const deleteRoleParams = {
+          roleId,
         };
 
-        const deleteRoleResult = iamPolicyManagementService.deleteRole(params);
+        const deleteRoleResult = iamPolicyManagementService.deleteRole(deleteRoleParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteRoleResult);
@@ -1171,7 +1194,7 @@ describe('IamPolicyManagementV1', () => {
         const roleId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteRoleParams = {
           roleId,
           headers: {
             Accept: userAccept,
@@ -1179,7 +1202,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.deleteRole(params);
+        iamPolicyManagementService.deleteRole(deleteRoleParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1200,6 +1223,588 @@ describe('IamPolicyManagementV1', () => {
         let err;
         try {
           await iamPolicyManagementService.deleteRole();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2ListPolicies', () => {
+    describe('positive tests', () => {
+      function __v2ListPoliciesTest() {
+        // Construct the params object for operation v2ListPolicies
+        const accountId = 'testString';
+        const acceptLanguage = 'default';
+        const iamId = 'testString';
+        const accessGroupId = 'testString';
+        const type = 'access';
+        const serviceType = 'service';
+        const serviceName = 'testString';
+        const serviceGroupId = 'testString';
+        const format = 'include_last_permit';
+        const state = 'active';
+        const v2ListPoliciesParams = {
+          accountId,
+          acceptLanguage,
+          iamId,
+          accessGroupId,
+          type,
+          serviceType,
+          serviceName,
+          serviceGroupId,
+          format,
+          state,
+        };
+
+        const v2ListPoliciesResult = iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2ListPoliciesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
+        expect(mockRequestOptions.qs.account_id).toEqual(accountId);
+        expect(mockRequestOptions.qs.iam_id).toEqual(iamId);
+        expect(mockRequestOptions.qs.access_group_id).toEqual(accessGroupId);
+        expect(mockRequestOptions.qs.type).toEqual(type);
+        expect(mockRequestOptions.qs.service_type).toEqual(serviceType);
+        expect(mockRequestOptions.qs.service_name).toEqual(serviceName);
+        expect(mockRequestOptions.qs.service_group_id).toEqual(serviceGroupId);
+        expect(mockRequestOptions.qs.format).toEqual(format);
+        expect(mockRequestOptions.qs.state).toEqual(state);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2ListPoliciesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2ListPoliciesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2ListPoliciesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const accountId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2ListPoliciesParams = {
+          accountId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2ListPolicies({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2ListPolicies();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2CreatePolicy', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // PolicyRole
+      const policyRoleModel = {
+        role_id: 'testString',
+      };
+
+      // V2PolicyBaseControlGrant
+      const v2PolicyBaseControlGrantModel = {
+        roles: [policyRoleModel],
+      };
+
+      // V2PolicyBaseControl
+      const v2PolicyBaseControlModel = {
+        grant: v2PolicyBaseControlGrantModel,
+      };
+
+      // V2PolicyAttribute
+      const v2PolicyAttributeModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      // V2PolicyBaseSubject
+      const v2PolicyBaseSubjectModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseResource
+      const v2PolicyBaseResourceModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseRuleV2PolicyAttribute
+      const v2PolicyBaseRuleModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      function __v2CreatePolicyTest() {
+        // Construct the params object for operation v2CreatePolicy
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const description = 'testString';
+        const subject = v2PolicyBaseSubjectModel;
+        const resource = v2PolicyBaseResourceModel;
+        const pattern = 'testString';
+        const rule = v2PolicyBaseRuleModel;
+        const acceptLanguage = 'default';
+        const v2CreatePolicyParams = {
+          type,
+          control,
+          description,
+          subject,
+          resource,
+          pattern,
+          rule,
+          acceptLanguage,
+        };
+
+        const v2CreatePolicyResult = iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2CreatePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.subject).toEqual(subject);
+        expect(mockRequestOptions.body.resource).toEqual(resource);
+        expect(mockRequestOptions.body.pattern).toEqual(pattern);
+        expect(mockRequestOptions.body.rule).toEqual(rule);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2CreatePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2CreatePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2CreatePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2CreatePolicyParams = {
+          type,
+          control,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2CreatePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2CreatePolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2UpdatePolicy', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // PolicyRole
+      const policyRoleModel = {
+        role_id: 'testString',
+      };
+
+      // V2PolicyBaseControlGrant
+      const v2PolicyBaseControlGrantModel = {
+        roles: [policyRoleModel],
+      };
+
+      // V2PolicyBaseControl
+      const v2PolicyBaseControlModel = {
+        grant: v2PolicyBaseControlGrantModel,
+      };
+
+      // V2PolicyAttribute
+      const v2PolicyAttributeModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      // V2PolicyBaseSubject
+      const v2PolicyBaseSubjectModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseResource
+      const v2PolicyBaseResourceModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseRuleV2PolicyAttribute
+      const v2PolicyBaseRuleModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      function __v2UpdatePolicyTest() {
+        // Construct the params object for operation v2UpdatePolicy
+        const policyId = 'testString';
+        const ifMatch = 'testString';
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const description = 'testString';
+        const subject = v2PolicyBaseSubjectModel;
+        const resource = v2PolicyBaseResourceModel;
+        const pattern = 'testString';
+        const rule = v2PolicyBaseRuleModel;
+        const v2UpdatePolicyParams = {
+          policyId,
+          ifMatch,
+          type,
+          control,
+          description,
+          subject,
+          resource,
+          pattern,
+          rule,
+        };
+
+        const v2UpdatePolicyResult = iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2UpdatePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'PUT');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.subject).toEqual(subject);
+        expect(mockRequestOptions.body.resource).toEqual(resource);
+        expect(mockRequestOptions.body.pattern).toEqual(pattern);
+        expect(mockRequestOptions.body.rule).toEqual(rule);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2UpdatePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2UpdatePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2UpdatePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const ifMatch = 'testString';
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2UpdatePolicyParams = {
+          policyId,
+          ifMatch,
+          type,
+          control,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2UpdatePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2UpdatePolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2GetPolicy', () => {
+    describe('positive tests', () => {
+      function __v2GetPolicyTest() {
+        // Construct the params object for operation v2GetPolicy
+        const policyId = 'testString';
+        const v2GetPolicyParams = {
+          policyId,
+        };
+
+        const v2GetPolicyResult = iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2GetPolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2GetPolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2GetPolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2GetPolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2GetPolicyParams = {
+          policyId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2GetPolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2GetPolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2DeletePolicy', () => {
+    describe('positive tests', () => {
+      function __v2DeletePolicyTest() {
+        // Construct the params object for operation v2DeletePolicy
+        const policyId = 'testString';
+        const v2DeletePolicyParams = {
+          policyId,
+        };
+
+        const v2DeletePolicyResult = iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2DeletePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2DeletePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2DeletePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2DeletePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2DeletePolicyParams = {
+          policyId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2DeletePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2DeletePolicy();
         } catch (e) {
           err = e;
         }


### PR DESCRIPTION
Signed-off-by: Shaun Colley <shaun.colley@ibm.com>

## PR summary
<!-- please include a brief summary of the changes in this PR -->
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.

Also updated test to remove use of callback `done()` with async/await (throws error to use one or other and followed pattern of [access groups](https://github.com/IBM/platform-services-node-sdk/blob/main/test/integration/iam-access-groups.v2.test.js#L77)).


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
PR's are currently open for staging and production docs. They are not currently merged:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No


## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md