### PR TITLE
feat(IAM Policy Management): add support for v2/policies

### DIFF
--- a/examples/iam-policy-management.v1.test.js
+++ b/examples/iam-policy-management.v1.test.js
@@ -327,6 +327,260 @@ describe('IamPolicyManagementV1', () => {
 
     // end-delete_policy
   });
+  test('v2CreatePolicy request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2CreatePolicy() result:');
+    // begin-v2_create_policy
+
+    const policySubject = {
+      attributes: [
+        {
+          key: 'iam_id',
+          operator: 'stringEquals',
+          value: exampleUserId,
+        },
+      ],
+    };
+    const policyResourceAccountAttribute = {
+      key: 'accountId',
+      value: exampleAccountId,
+      operator: 'stringEquals',
+    };
+    const policyResourceServiceAttribute = {
+      key: 'serviceType',
+      operator: 'stringEquals',
+      value: 'service',
+    };
+    const policyResource = {
+      attributes: [policyResourceAccountAttribute, policyResourceServiceAttribute]
+    };
+    const policyControl = {
+      grant: {
+        roles: [{
+          role_id: 'crn:v1:bluemix:public:iam::::role:Viewer',
+        }],
+      }
+    };
+    const policyRule = {
+      operator: 'and',
+      conditions: [
+          {
+              key: '{{environment.attributes.day_of_week}}',
+              operator: 'dayOfWeekAnyOf',
+              value: [1, 2, 3, 4, 5],
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeGreaterThanOrEquals',
+              value: '09:00:00+00:00',
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeLessThanOrEquals',
+              value: '17:00:00+00:00',
+          },
+      ],
+    }
+    const policyPattern = 'time-based-restrictions:weekly'
+    const params = {
+      type: 'access',
+      subject: policySubject,
+      control: policyControl,
+      resource: policyResource,
+      rule: policyRule,
+      pattern: policyPattern,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2CreatePolicy(params);
+      examplePolicyId = res.result.id;
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_create_policy
+  });
+  test('v2GetPolicy request example', async () => {
+    expect(examplePolicyId).toBeDefined();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2GetPolicy() result:');
+    // begin-v2_get_policy
+
+    const params = {
+      policyId: examplePolicyId,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2GetPolicy(params);
+      examplePolicyETag = res.headers.etag;
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_get_policy
+  });
+  test('v2UpdatePolicy request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+    expect(examplePolicyId).toBeDefined();
+    expect(examplePolicyETag).toBeDefined();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2UpdatePolicy() result:');
+    // begin-v2_update_policy
+
+    const policySubject = {
+      attributes: [
+        {
+          key: 'iam_id',
+          operator: 'stringEquals',
+          value: exampleUserId,
+        },
+      ],
+    };
+    const policyResourceAccountAttribute = {
+      key: 'accountId',
+      value: exampleAccountId,
+      operator: 'stringEquals',
+    };
+    const policyResourceServiceAttribute = {
+      key: 'serviceType',
+      operator: 'stringEquals',
+      value: 'service',
+    };
+    const policyResource = {
+      attributes: [policyResourceAccountAttribute, policyResourceServiceAttribute]
+    };
+    const updatedPolicyControl = {
+      grant: {
+        roles: [{
+          role_id: 'crn:v1:bluemix:public:iam::::role:Editor',
+        }],
+      }
+    };
+    const policyRule = {
+      operator: 'and',
+      conditions: [
+          {
+              key: '{{environment.attributes.day_of_week}}',
+              operator: 'dayOfWeekAnyOf',
+              value: [1, 2, 3, 4, 5],
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeGreaterThanOrEquals',
+              value: '09:00:00+00:00',
+          },
+          {
+              key: '{{environment.attributes.current_time}}',
+              operator: 'timeLessThanOrEquals',
+              value: '17:00:00+00:00',
+          },
+      ],
+    }
+    const policyPattern = 'time-based-restrictions:weekly'
+    const params = {
+      type: 'access',
+      policyId: examplePolicyId,
+      ifMatch: examplePolicyETag,
+      subject: policySubject,
+      control: updatedPolicyControl,
+      resource: policyResource,
+      rule: policyRule,
+      pattern: policyPattern,
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2UpdatePolicy(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err)
+    }
+
+    // end-v2_update_policy
+  });
+  test('v2ListPolicies request example', async () => {
+    expect(exampleAccountId).not.toBeNull();
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('v2ListPolicies() result:');
+    // begin-v2_list_policies
+
+    const params = {
+      accountId: exampleAccountId,
+      iamId: exampleUserId,
+      format: 'include_last_permit',
+    };
+
+    try {
+      const res = await iamPolicyManagementService.v2ListPolicies(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-v2_list_policies
+  });
+  test('v2DeletePolicy request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    // begin-v2_delete_policy
+
+    const params = {
+      policyId: examplePolicyId,
+    };
+
+    try {
+      await iamPolicyManagementService.v2DeletePolicy(params);
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-v2_delete_policy
+  });
   test('createRole request example', async () => {
     expect(exampleAccountId).not.toBeNull();
 

--- a/examples/iam-policy-management.v1.test.js
+++ b/examples/iam-policy-management.v1.test.js
@@ -57,6 +57,7 @@ describe('IamPolicyManagementV1', () => {
   let examplePolicyETag;
   let exampleCustomRoleId;
   let exampleCustomRoleEtag;
+  const exampleCustomRoleDipslayName = 'IAM Groups read access';
   const exampleUserId = 'IBMid-user1';
   const exampleServiceName = 'iam-groups';
 
@@ -169,7 +170,7 @@ describe('IamPolicyManagementV1', () => {
 
     // end-get_policy
   });
-  test('updatePolicy request example', async () => {
+  test('replacePolicy request example', async () => {
     expect(exampleAccountId).not.toBeNull();
     expect(examplePolicyId).toBeDefined();
     expect(examplePolicyETag).toBeDefined();
@@ -183,7 +184,7 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('updatePolicy() result:');
+    originalLog('replacePolicy() result:');
     // begin-update_policy
 
     const policySubjects = [
@@ -232,7 +233,7 @@ describe('IamPolicyManagementV1', () => {
     };
 
     try {
-      const res = await iamPolicyManagementService.updatePolicy(params);
+      const res = await iamPolicyManagementService.replacePolicy(params);
       examplePolicyETag = res.headers.etag;
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
@@ -241,7 +242,7 @@ describe('IamPolicyManagementV1', () => {
 
     // end-update_policy
   });
-  test('patchPolicy request example', async () => {
+  test('updatePolicyState request example', async () => {
     expect(examplePolicyId).toBeDefined();
     expect(examplePolicyETag).toBeDefined();
 
@@ -254,7 +255,7 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('patchPolicy() result:');
+    originalLog('updatePolicyState() result:');
     // begin-patch_policy
 
     const params = {
@@ -264,7 +265,7 @@ describe('IamPolicyManagementV1', () => {
     };
 
     try {
-      const res = await iamPolicyManagementService.patchPolicy(params);
+      const res = await iamPolicyManagementService.updatePolicyState(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err)
@@ -327,7 +328,7 @@ describe('IamPolicyManagementV1', () => {
 
     // end-delete_policy
   });
-  test('v2CreatePolicy request example', async () => {
+  test('createV2Policy request example', async () => {
     expect(exampleAccountId).not.toBeNull();
 
     consoleLogMock.mockImplementation(output => {
@@ -338,8 +339,8 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('v2CreatePolicy() result:');
-    // begin-v2_create_policy
+    originalLog('createV2Policy() result:');
+    // begin-create_v2_policy
 
     const policySubject = {
       attributes: [
@@ -376,7 +377,7 @@ describe('IamPolicyManagementV1', () => {
           {
               key: '{{environment.attributes.day_of_week}}',
               operator: 'dayOfWeekAnyOf',
-              value: [1, 2, 3, 4, 5],
+              value: ['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
           },
           {
               key: '{{environment.attributes.current_time}}',
@@ -390,7 +391,7 @@ describe('IamPolicyManagementV1', () => {
           },
       ],
     }
-    const policyPattern = 'time-based-restrictions:weekly'
+    const policyPattern = 'time-based-conditions:weekly:custom-hours'
     const params = {
       type: 'access',
       subject: policySubject,
@@ -401,16 +402,16 @@ describe('IamPolicyManagementV1', () => {
     };
 
     try {
-      const res = await iamPolicyManagementService.v2CreatePolicy(params);
+      const res = await iamPolicyManagementService.createV2Policy(params);
       examplePolicyId = res.result.id;
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err)
     }
 
-    // end-v2_create_policy
+    // end-create_v2_policy
   });
-  test('v2GetPolicy request example', async () => {
+  test('getV2Policy request example', async () => {
     expect(examplePolicyId).toBeDefined();
 
     consoleLogMock.mockImplementation(output => {
@@ -422,24 +423,24 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('v2GetPolicy() result:');
-    // begin-v2_get_policy
+    originalLog('getV2Policy() result:');
+    // begin-get_v2_policy
 
     const params = {
-      policyId: examplePolicyId,
+      id: examplePolicyId,
     };
 
     try {
-      const res = await iamPolicyManagementService.v2GetPolicy(params);
+      const res = await iamPolicyManagementService.getV2Policy(params);
       examplePolicyETag = res.headers.etag;
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err)
     }
 
-    // end-v2_get_policy
+    // end-get_v2_policy
   });
-  test('v2UpdatePolicy request example', async () => {
+  test('replaceV2Policy request example', async () => {
     expect(exampleAccountId).not.toBeNull();
     expect(examplePolicyId).toBeDefined();
     expect(examplePolicyETag).toBeDefined();
@@ -453,8 +454,8 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('v2UpdatePolicy() result:');
-    // begin-v2_update_policy
+    originalLog('replaceV2Policy() result:');
+    // begin-replace_v2_policy
 
     const policySubject = {
       attributes: [
@@ -491,7 +492,7 @@ describe('IamPolicyManagementV1', () => {
           {
               key: '{{environment.attributes.day_of_week}}',
               operator: 'dayOfWeekAnyOf',
-              value: [1, 2, 3, 4, 5],
+              value: ['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
           },
           {
               key: '{{environment.attributes.current_time}}',
@@ -505,10 +506,10 @@ describe('IamPolicyManagementV1', () => {
           },
       ],
     }
-    const policyPattern = 'time-based-restrictions:weekly'
+    const policyPattern = 'time-based-conditions:weekly:custom-hours'
     const params = {
       type: 'access',
-      policyId: examplePolicyId,
+      id: examplePolicyId,
       ifMatch: examplePolicyETag,
       subject: policySubject,
       control: updatedPolicyControl,
@@ -518,15 +519,15 @@ describe('IamPolicyManagementV1', () => {
     };
 
     try {
-      const res = await iamPolicyManagementService.v2UpdatePolicy(params);
+      const res = await iamPolicyManagementService.replaceV2Policy(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err)
     }
 
-    // end-v2_update_policy
+    // end-replace_v2_policy
   });
-  test('v2ListPolicies request example', async () => {
+  test('listV2Policies request example', async () => {
     expect(exampleAccountId).not.toBeNull();
 
     consoleLogMock.mockImplementation(output => {
@@ -538,8 +539,8 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('v2ListPolicies() result:');
-    // begin-v2_list_policies
+    originalLog('listV2Policies() result:');
+    // begin-list_v2_policy
 
     const params = {
       accountId: exampleAccountId,
@@ -548,15 +549,15 @@ describe('IamPolicyManagementV1', () => {
     };
 
     try {
-      const res = await iamPolicyManagementService.v2ListPolicies(params);
+      const res = await iamPolicyManagementService.listV2Policies(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err);
     }
 
-    // end-v2_list_policies
+    // end-list_v2_policy
   });
-  test('v2DeletePolicy request example', async () => {
+  test('deleteV2Policy request example', async () => {
 
     consoleLogMock.mockImplementation(output => {
       originalLog(output);
@@ -567,19 +568,19 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    // begin-v2_delete_policy
+    // begin-delete_v2_policy
 
     const params = {
-      policyId: examplePolicyId,
+      id: examplePolicyId,
     };
 
     try {
-      await iamPolicyManagementService.v2DeletePolicy(params);
+      await iamPolicyManagementService.deleteV2Policy(params);
     } catch (err) {
       console.warn(err);
     }
 
-    // end-v2_delete_policy
+    // end-delete_v2_policy
   });
   test('createRole request example', async () => {
     expect(exampleAccountId).not.toBeNull();
@@ -597,7 +598,7 @@ describe('IamPolicyManagementV1', () => {
     // begin-create_role
 
     const params = {
-      displayName: 'IAM Groups read access',
+      displayName: exampleCustomRoleDipslayName,
       actions: ['iam-groups.groups.read'],
       name: 'ExampleRoleIAMGroups',
       accountId: exampleAccountId,
@@ -643,7 +644,7 @@ describe('IamPolicyManagementV1', () => {
 
     // end-get_role
   });
-  test('updateRole request example', async () => {
+  test('replaceRole request example', async () => {
     expect(exampleCustomRoleId).toBeDefined();
     expect(exampleCustomRoleEtag).toBeDefined();
 
@@ -656,18 +657,19 @@ describe('IamPolicyManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('updateRole() result:');
+    originalLog('replaceRole() result:');
     // begin-update_role
 
     const updatedRoleActions = ['iam-groups.groups.read', 'iam-groups.groups.list'];
     const params = {
       roleId: exampleCustomRoleId,
       ifMatch: exampleCustomRoleEtag,
+      displayName: exampleCustomRoleDipslayName,
       actions: updatedRoleActions,
     };
 
     try {
-      const res = await iamPolicyManagementService.updateRole(params);
+      const res = await iamPolicyManagementService.replaceRole(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err);

--- a/iam-policy-management/v1.ts
+++ b/iam-policy-management/v1.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.62.0-a2a22f95-20221115-162524
+ * IBM OpenAPI SDK Code Generator Version: 3.64.0-959a5845-20230112-195144
  */
 
 import * as extend from 'extend';
@@ -103,7 +103,9 @@ class IamPolicyManagementV1 extends BaseService {
    * and filter by attribute values. This can be done through query parameters. Currently, only the following attributes
    * are supported: account_id, iam_id, access_group_id, type, service_type, sort, format and state. account_id is a
    * required query parameter. Only policies that have the specified attributes and that the caller has read access to
-   * are returned. If the caller does not have read access to any policies an empty array is returned.
+   * are returned. If the caller does not have read access to any policies an empty array is returned. If a policy was
+   * created using the new beta v2/policies API, then the caller will see placeholder information, e.g., "unsupported
+   * version" for iam_id, and a valid v2/policies href. The caller should use this href to view the policy.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.accountId - The account GUID in which the policies belong to.
@@ -375,8 +377,8 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>>}
    */
-  public updatePolicy(
-    params: IamPolicyManagementV1.UpdatePolicyParams
+  public replacePolicy(
+    params: IamPolicyManagementV1.ReplacePolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
     const _requiredParams = ['policyId', 'ifMatch', 'type', 'subjects', 'roles', 'resources'];
@@ -410,7 +412,7 @@ class IamPolicyManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'updatePolicy'
+      'replacePolicy'
     );
 
     const parameters = {
@@ -546,8 +548,8 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>>}
    */
-  public patchPolicy(
-    params: IamPolicyManagementV1.PatchPolicyParams
+  public updatePolicyState(
+    params: IamPolicyManagementV1.UpdatePolicyStateParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.Policy>> {
     const _params = { ...params };
     const _requiredParams = ['policyId', 'ifMatch'];
@@ -568,7 +570,7 @@ class IamPolicyManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'patchPolicy'
+      'updatePolicyState'
     );
 
     const parameters = {
@@ -776,19 +778,19 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {string} params.ifMatch - The revision number for updating a role and must match the ETag value of the
    * existing role. The Etag can be retrieved using the GET /v2/roles/{role_id} API and looking at the ETag response
    * header.
-   * @param {string} [params.displayName] - The display name of the role that is shown in the console.
-   * @param {string} [params.description] - The description of the role.
-   * @param {string[]} [params.actions] - The actions of the role. Please refer to [IAM roles and
+   * @param {string} params.displayName - The display name of the role that is shown in the console.
+   * @param {string[]} params.actions - The actions of the role. Please refer to [IAM roles and
    * actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+   * @param {string} [params.description] - The description of the role.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.CustomRole>>}
    */
-  public updateRole(
-    params: IamPolicyManagementV1.UpdateRoleParams
+  public replaceRole(
+    params: IamPolicyManagementV1.ReplaceRoleParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.CustomRole>> {
     const _params = { ...params };
-    const _requiredParams = ['roleId', 'ifMatch'];
-    const _validParams = ['roleId', 'ifMatch', 'displayName', 'description', 'actions', 'headers'];
+    const _requiredParams = ['roleId', 'ifMatch', 'displayName', 'actions'];
+    const _validParams = ['roleId', 'ifMatch', 'displayName', 'actions', 'description', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -796,8 +798,8 @@ class IamPolicyManagementV1 extends BaseService {
 
     const body = {
       'display_name': _params.displayName,
-      'description': _params.description,
       'actions': _params.actions,
+      'description': _params.description,
     };
 
     const path = {
@@ -807,7 +809,7 @@ class IamPolicyManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'updateRole'
+      'replaceRole'
     );
 
     const parameters = {
@@ -968,11 +970,11 @@ class IamPolicyManagementV1 extends BaseService {
    * * `active` - returns active policies
    * * `deleted` - returns non-active policies.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>>}
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyCollection>>}
    */
-  public v2ListPolicies(
-    params: IamPolicyManagementV1.V2ListPoliciesParams
-  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>> {
+  public listV2Policies(
+    params: IamPolicyManagementV1.ListV2PoliciesParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyCollection>> {
     const _params = { ...params };
     const _requiredParams = ['accountId'];
     const _validParams = [
@@ -1008,7 +1010,7 @@ class IamPolicyManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'v2ListPolicies'
+      'listV2Policies'
     );
 
     const parameters = {
@@ -1045,21 +1047,23 @@ class IamPolicyManagementV1 extends BaseService {
    * To create an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
    * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
    * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
-   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
-   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
-   * **`serviceName`**, **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.`
-   * The rule field can either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`**
-   * with a combination **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field
-   * has a maximum of 2 levels of nested **`conditions`**. The operator for a rule can be used to specify a time based
-   * restriction (e.g., access only during business hours, during the Monday-Friday work week). For example, a policy
-   * can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+   * must be a subset of a service's or the platform's supported roles. For more information, see [IAM roles and
+   * actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions). The resource attributes must
+   * be a subset of a service's or the platform's supported attributes. Caller should check with service, e.g.,
+   * [VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-resource-attributes), to view supported attributes. The policy
+   * resource must include either the **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
+   * **`service_group_id`** attribute and the **`accountId`** attribute.` The rule field can either specify single
+   * **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination **`operator`**.  The
+   * possible combination operator are **`and`** and **`or`**. The operator for a rule can be used to specify a
+   * time-based condition (e.g., access only during business hours, during the Monday-Friday work week). For example, a
+   * policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
    * ```json
    *   "rule": {
    *     "operator": "and",
    *     "conditions": [{
    *       "key": "{{environment.attributes.day_of_week}}",
    *       "operator": "dayOfWeekAnyOf",
-   *       "value": [1, 2, 3, 4, 5]
+   *       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
    *     },
    *       "key": "{{environment.attributes.current_time}}",
    *       "operator": "timeGreaterThanOrEquals",
@@ -1073,15 +1077,19 @@ class IamPolicyManagementV1 extends BaseService {
    * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
    * ```
    *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
    *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
    *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
-   *   'monthEquals', 'monthAnyOf',
-   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
-   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
-   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset of
-   * account management services that includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
-   * Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the request will fail.
+   * ```
+   *
+   * The pattern field that matches the rule is required when rule is provided. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
+   * operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
+   * and
+   * [Limiting access with time-based
+   * conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui). The IAM Services group
+   * (`IAM`) is a subset of account management services that includes the IAM platform services IAM Identity, IAM Access
+   * Management, IAM Users Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the
+   * request will fail.
    *
    * ### Attribute Operators
    *
@@ -1096,13 +1104,15 @@ class IamPolicyManagementV1 extends BaseService {
    * against Global Catalog locations.
    *
    * @param {Object} params - The parameters to send to the service.
+   * @param {Control} params.control - Specifies the type of access granted by the policy.
    * @param {string} params.type - The policy type; either 'access' or 'authorization'.
-   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
-   * @param {string} [params.description] - Customer-defined description.
-   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
-   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
-   * @param {string} [params.pattern] - Indicates pattern of rule.
-   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {string} [params.description] - Allows the customer to use their own words to record the purpose/context
+   * related to a policy.
+   * @param {V2PolicySubject} [params.subject] - The subject attributes for whom the policy grants access.
+   * @param {V2PolicyResource} [params.resource] - The resource attributes to which the policy grants access.
+   * @param {string} [params.pattern] - Indicates pattern of rule, either 'time-based-conditions:once',
+   * 'time-based-conditions:weekly:all-day', or 'time-based-conditions:weekly:custom-hours'.
+   * @param {V2PolicyRule} [params.rule] - Additional access conditions associated with the policy.
    * @param {string} [params.acceptLanguage] - Language code for translations
    * * `default` - English
    * * `de` -  German (Standard)
@@ -1118,14 +1128,14 @@ class IamPolicyManagementV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
    */
-  public v2CreatePolicy(
-    params: IamPolicyManagementV1.V2CreatePolicyParams
+  public createV2Policy(
+    params: IamPolicyManagementV1.CreateV2PolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
     const _params = { ...params };
-    const _requiredParams = ['type', 'control'];
+    const _requiredParams = ['control', 'type'];
     const _validParams = [
-      'type',
       'control',
+      'type',
       'description',
       'subject',
       'resource',
@@ -1140,8 +1150,8 @@ class IamPolicyManagementV1 extends BaseService {
     }
 
     const body = {
-      'type': _params.type,
       'control': _params.control,
+      'type': _params.type,
       'description': _params.description,
       'subject': _params.subject,
       'resource': _params.resource,
@@ -1152,7 +1162,7 @@ class IamPolicyManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'v2CreatePolicy'
+      'createV2Policy'
     );
 
     const parameters = {
@@ -1189,21 +1199,23 @@ class IamPolicyManagementV1 extends BaseService {
    * To update an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
    * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
    * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
-   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
-   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
-   * **`serviceName`**,  or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can
-   * either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
-   * **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
-   * levels of nested **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g.,
-   * access only during business hours, during the Monday-Friday work week). For example, a policy can grant access
-   * Monday-Friday, 9:00am-5:00pm using the following rule:
+   * must be a subset of a service's or the platform's supported roles. For more information, see [IAM roles and
+   * actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions). The resource attributes must
+   * be a subset of a service's or the platform's supported attributes. Caller should check with service, e.g.,
+   * [VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-resource-attributes), to view supported attributes. The policy
+   * resource must include either the **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute and the
+   * **`accountId`** attribute.` The rule field can either specify single **`key`**, **`value`**, and **`operator`** or
+   * be set of **`conditions`** with a combination **`operator`**.  The possible combination operator are **`and`** and
+   * **`or`**. The operator for a rule can be used to specify a time-based condition (e.g., access only during business
+   * hours, during the Monday-Friday work week). For example, a policy can grant access Monday-Friday, 9:00am-5:00pm
+   * using the following rule:
    * ```json
    *   "rule": {
    *     "operator": "and",
    *     "conditions": [{
    *       "key": "{{environment.attributes.day_of_week}}",
    *       "operator": "dayOfWeekAnyOf",
-   *       "value": [1, 2, 3, 4, 5]
+   *       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
    *     },
    *       "key": "{{environment.attributes.current_time}}",
    *       "operator": "timeGreaterThanOrEquals",
@@ -1217,14 +1229,14 @@ class IamPolicyManagementV1 extends BaseService {
    * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
    * ```
    *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
    *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
    *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
-   *   'monthEquals', 'monthAnyOf',
-   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
-   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
-   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
-   * request will fail.
+   * ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
+   * operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
+   * and
+   * [Limiting access with time-based
+   * conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui).
    *
    * ### Attribute Operators
    *
@@ -1239,30 +1251,32 @@ class IamPolicyManagementV1 extends BaseService {
    * against Global Catalog locations.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.policyId - The policy ID.
+   * @param {string} params.id - The policy ID.
    * @param {string} params.ifMatch - The revision number for updating a policy and must match the ETag value of the
-   * existing policy. The Etag can be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag
-   * response header.
+   * existing policy. The Etag can be retrieved using the GET /v2/policies/{id} API and looking at the ETag response
+   * header.
+   * @param {Control} params.control - Specifies the type of access granted by the policy.
    * @param {string} params.type - The policy type; either 'access' or 'authorization'.
-   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
-   * @param {string} [params.description] - Customer-defined description.
-   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
-   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
-   * @param {string} [params.pattern] - Indicates pattern of rule.
-   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {string} [params.description] - Allows the customer to use their own words to record the purpose/context
+   * related to a policy.
+   * @param {V2PolicySubject} [params.subject] - The subject attributes for whom the policy grants access.
+   * @param {V2PolicyResource} [params.resource] - The resource attributes to which the policy grants access.
+   * @param {string} [params.pattern] - Indicates pattern of rule, either 'time-based-conditions:once',
+   * 'time-based-conditions:weekly:all-day', or 'time-based-conditions:weekly:custom-hours'.
+   * @param {V2PolicyRule} [params.rule] - Additional access conditions associated with the policy.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
    */
-  public v2UpdatePolicy(
-    params: IamPolicyManagementV1.V2UpdatePolicyParams
+  public replaceV2Policy(
+    params: IamPolicyManagementV1.ReplaceV2PolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
     const _params = { ...params };
-    const _requiredParams = ['policyId', 'ifMatch', 'type', 'control'];
+    const _requiredParams = ['id', 'ifMatch', 'control', 'type'];
     const _validParams = [
-      'policyId',
+      'id',
       'ifMatch',
-      'type',
       'control',
+      'type',
       'description',
       'subject',
       'resource',
@@ -1276,8 +1290,8 @@ class IamPolicyManagementV1 extends BaseService {
     }
 
     const body = {
-      'type': _params.type,
       'control': _params.control,
+      'type': _params.type,
       'description': _params.description,
       'subject': _params.subject,
       'resource': _params.resource,
@@ -1286,18 +1300,18 @@ class IamPolicyManagementV1 extends BaseService {
     };
 
     const path = {
-      'policy_id': _params.policyId,
+      'id': _params.id,
     };
 
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'v2UpdatePolicy'
+      'replaceV2Policy'
     );
 
     const parameters = {
       options: {
-        url: '/v2/policies/{policy_id}',
+        url: '/v2/policies/{id}',
         method: 'PUT',
         body,
         path,
@@ -1325,34 +1339,34 @@ class IamPolicyManagementV1 extends BaseService {
    * Retrieve a policy by providing a policy ID.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.policyId - The policy ID.
+   * @param {string} params.id - The policy ID.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
    */
-  public v2GetPolicy(
-    params: IamPolicyManagementV1.V2GetPolicyParams
+  public getV2Policy(
+    params: IamPolicyManagementV1.GetV2PolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
     const _params = { ...params };
-    const _requiredParams = ['policyId'];
-    const _validParams = ['policyId', 'headers'];
+    const _requiredParams = ['id'];
+    const _validParams = ['id', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
     }
 
     const path = {
-      'policy_id': _params.policyId,
+      'id': _params.id,
     };
 
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'v2GetPolicy'
+      'getV2Policy'
     );
 
     const parameters = {
       options: {
-        url: '/v2/policies/{policy_id}',
+        url: '/v2/policies/{id}',
         method: 'GET',
         path,
       },
@@ -1378,34 +1392,34 @@ class IamPolicyManagementV1 extends BaseService {
    * ID. If the subject of the policy is a locked service-id, the request will fail.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.policyId - The policy ID.
+   * @param {string} params.id - The policy ID.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>>}
    */
-  public v2DeletePolicy(
-    params: IamPolicyManagementV1.V2DeletePolicyParams
+  public deleteV2Policy(
+    params: IamPolicyManagementV1.DeleteV2PolicyParams
   ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>> {
     const _params = { ...params };
-    const _requiredParams = ['policyId'];
-    const _validParams = ['policyId', 'headers'];
+    const _requiredParams = ['id'];
+    const _validParams = ['id', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
     }
 
     const path = {
-      'policy_id': _params.policyId,
+      'id': _params.id,
     };
 
     const sdkHeaders = getSdkHeaders(
       IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'v2DeletePolicy'
+      'deleteV2Policy'
     );
 
     const parameters = {
       options: {
-        url: '/v2/policies/{policy_id}',
+        url: '/v2/policies/{id}',
         method: 'DELETE',
         path,
       },
@@ -1555,8 +1569,8 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `updatePolicy` operation. */
-  export interface UpdatePolicyParams {
+  /** Parameters for the `replacePolicy` operation. */
+  export interface ReplacePolicyParams {
     /** The policy ID. */
     policyId: string;
     /** The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can
@@ -1590,8 +1604,8 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `patchPolicy` operation. */
-  export interface PatchPolicyParams {
+  /** Parameters for the `updatePolicyState` operation. */
+  export interface UpdatePolicyStateParams {
     /** The policy ID. */
     policyId: string;
     /** The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can
@@ -1599,12 +1613,12 @@ namespace IamPolicyManagementV1 {
      */
     ifMatch: string;
     /** The policy state. */
-    state?: PatchPolicyConstants.State | string;
+    state?: UpdatePolicyStateConstants.State | string;
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Constants for the `patchPolicy` operation. */
-  export namespace PatchPolicyConstants {
+  /** Constants for the `updatePolicyState` operation. */
+  export namespace UpdatePolicyStateConstants {
     /** The policy state. */
     export enum State {
       ACTIVE = 'active',
@@ -1672,8 +1686,8 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `updateRole` operation. */
-  export interface UpdateRoleParams {
+  /** Parameters for the `replaceRole` operation. */
+  export interface ReplaceRoleParams {
     /** The role ID. */
     roleId: string;
     /** The revision number for updating a role and must match the ETag value of the existing role. The Etag can be
@@ -1681,13 +1695,13 @@ namespace IamPolicyManagementV1 {
      */
     ifMatch: string;
     /** The display name of the role that is shown in the console. */
-    displayName?: string;
-    /** The description of the role. */
-    description?: string;
+    displayName: string;
     /** The actions of the role. Please refer to [IAM roles and
      *  actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
      */
-    actions?: string[];
+    actions: string[];
+    /** The description of the role. */
+    description?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -1705,8 +1719,8 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `v2ListPolicies` operation. */
-  export interface V2ListPoliciesParams {
+  /** Parameters for the `listV2Policies` operation. */
+  export interface ListV2PoliciesParams {
     /** The account GUID in which the policies belong to. */
     accountId: string;
     /** Language code for translations
@@ -1728,9 +1742,9 @@ namespace IamPolicyManagementV1 {
     /** Optional access group id. */
     accessGroupId?: string;
     /** Optional type of policy. */
-    type?: V2ListPoliciesConstants.Type | string;
+    type?: ListV2PoliciesConstants.Type | string;
     /** Optional type of service. */
-    serviceType?: V2ListPoliciesConstants.ServiceType | string;
+    serviceType?: ListV2PoliciesConstants.ServiceType | string;
     /** Optional name of service. */
     serviceName?: string;
     /** Optional ID of service group. */
@@ -1741,14 +1755,14 @@ namespace IamPolicyManagementV1 {
      *  * `display` - returns the list of all actions included in each of the policy roles and translations for all
      *  relevant fields.
      */
-    format?: V2ListPoliciesConstants.Format | string;
+    format?: ListV2PoliciesConstants.Format | string;
     /** The state of the policy. * `active` - returns active policies * `deleted` - returns non-active policies. */
-    state?: V2ListPoliciesConstants.State | string;
+    state?: ListV2PoliciesConstants.State | string;
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Constants for the `v2ListPolicies` operation. */
-  export namespace V2ListPoliciesConstants {
+  /** Constants for the `listV2Policies` operation. */
+  export namespace ListV2PoliciesConstants {
     /** Optional type of policy. */
     export enum Type {
       ACCESS = 'access',
@@ -1771,22 +1785,24 @@ namespace IamPolicyManagementV1 {
     }
   }
 
-  /** Parameters for the `v2CreatePolicy` operation. */
-  export interface V2CreatePolicyParams {
-    /** The policy type; either 'access' or 'authorization'. */
-    type: string;
+  /** Parameters for the `createV2Policy` operation. */
+  export interface CreateV2PolicyParams {
     /** Specifies the type of access granted by the policy. */
-    control: V2PolicyBaseControl;
-    /** Customer-defined description. */
+    control: Control;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: CreateV2PolicyConstants.Type | string;
+    /** Allows the customer to use their own words to record the purpose/context related to a policy. */
     description?: string;
-    /** The subject attributes associated with a policy. */
-    subject?: V2PolicyBaseSubject;
-    /** The resource attributes associated with a policy. */
-    resource?: V2PolicyBaseResource;
-    /** Indicates pattern of rule. */
+    /** The subject attributes for whom the policy grants access. */
+    subject?: V2PolicySubject;
+    /** The resource attributes to which the policy grants access. */
+    resource?: V2PolicyResource;
+    /** Indicates pattern of rule, either 'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+     *  'time-based-conditions:weekly:custom-hours'.
+     */
     pattern?: string;
-    /** Additional access conditions associated with a policy. */
-    rule?: V2PolicyBaseRule;
+    /** Additional access conditions associated with the policy. */
+    rule?: V2PolicyRule;
     /** Language code for translations
      *  * `default` - English
      *  * `de` -  German (Standard)
@@ -1804,42 +1820,62 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `v2UpdatePolicy` operation. */
-  export interface V2UpdatePolicyParams {
+  /** Constants for the `createV2Policy` operation. */
+  export namespace CreateV2PolicyConstants {
+    /** The policy type; either 'access' or 'authorization'. */
+    export enum Type {
+      ACCESS = 'access',
+      AUTHORIZATION = 'authorization',
+    }
+  }
+
+  /** Parameters for the `replaceV2Policy` operation. */
+  export interface ReplaceV2PolicyParams {
     /** The policy ID. */
-    policyId: string;
+    id: string;
     /** The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can
-     *  be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag response header.
+     *  be retrieved using the GET /v2/policies/{id} API and looking at the ETag response header.
      */
     ifMatch: string;
-    /** The policy type; either 'access' or 'authorization'. */
-    type: string;
     /** Specifies the type of access granted by the policy. */
-    control: V2PolicyBaseControl;
-    /** Customer-defined description. */
+    control: Control;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: ReplaceV2PolicyConstants.Type | string;
+    /** Allows the customer to use their own words to record the purpose/context related to a policy. */
     description?: string;
-    /** The subject attributes associated with a policy. */
-    subject?: V2PolicyBaseSubject;
-    /** The resource attributes associated with a policy. */
-    resource?: V2PolicyBaseResource;
-    /** Indicates pattern of rule. */
+    /** The subject attributes for whom the policy grants access. */
+    subject?: V2PolicySubject;
+    /** The resource attributes to which the policy grants access. */
+    resource?: V2PolicyResource;
+    /** Indicates pattern of rule, either 'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+     *  'time-based-conditions:weekly:custom-hours'.
+     */
     pattern?: string;
-    /** Additional access conditions associated with a policy. */
-    rule?: V2PolicyBaseRule;
+    /** Additional access conditions associated with the policy. */
+    rule?: V2PolicyRule;
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `v2GetPolicy` operation. */
-  export interface V2GetPolicyParams {
+  /** Constants for the `replaceV2Policy` operation. */
+  export namespace ReplaceV2PolicyConstants {
+    /** The policy type; either 'access' or 'authorization'. */
+    export enum Type {
+      ACCESS = 'access',
+      AUTHORIZATION = 'authorization',
+    }
+  }
+
+  /** Parameters for the `getV2Policy` operation. */
+  export interface GetV2PolicyParams {
     /** The policy ID. */
-    policyId: string;
+    id: string;
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `v2DeletePolicy` operation. */
-  export interface V2DeletePolicyParams {
+  /** Parameters for the `deleteV2Policy` operation. */
+  export interface DeleteV2PolicyParams {
     /** The policy ID. */
-    policyId: string;
+    id: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -1848,30 +1884,168 @@ namespace IamPolicyManagementV1 {
    ************************/
 
   /** Specifies the type of access granted by the policy. */
-  export interface V2PolicyBaseControl {
+  export interface Control {
     /** Permission granted by the policy. */
-    grant: V2PolicyBaseControlGrant;
+    grant: V2PolicyGrant;
+  }
+
+  /** ControlResponse. */
+  export interface ControlResponse {}
+
+  /** Permission granted by the policy with translated roles and additional role information. */
+  export interface GrantWithTranslatedRoles {
+    /** A set of roles granted by the policy. */
+    roles: RoleInDisplayFormat[];
+  }
+
+  /** A role associated with a policy. */
+  export interface PolicyRole {
+    /** The role Cloud Resource Name (CRN) granted by the policy. Example CRN:
+     *  'crn:v1:bluemix:public:iam::::role:Editor'.
+     */
+    role_id: string;
+    /** The display name of the role. */
+    display_name?: string;
+    /** The description of the role. */
+    description?: string;
+  }
+
+  /** An action that can be performed by the policy subject when assigned role. */
+  export interface RoleAction {
+    /** Unique identifier for action with structure service.resource.action e.g., cbr.rule.read. */
+    id: string;
+    /** Service defined display name for action. */
+    display_name: string;
+    /** Service defined description for action. */
+    description: string;
+  }
+
+  /** A role associated with a policy with additional information (display_name, description, actions) when `format=display`. */
+  export interface RoleInDisplayFormat {
+    /** The role Cloud Resource Name (CRN) granted by the policy. Example CRN:
+     *  'crn:v1:bluemix:public:iam::::role:Editor'.
+     */
+    role_id: string;
+    /** The service defined (or user defined if a custom role) display name of the role. */
+    display_name?: string;
+    /** The service defined (or user defined if a custom role) description of the role. */
+    description?: string;
+    /** The actions of the role. Please refer to [IAM roles and
+     *  actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
+     */
+    actions: RoleAction[];
+  }
+
+  /** Rule that specifies additional access granted (e.g., time-based condition). */
+  export interface RuleAttribute {
+    /** The name of an attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an rule or resource attribute; can be boolean or string for resource attribute. Can be a string
+     *  or an array of strings (e.g., array of days to permit access) for rule attribute.
+     */
+    value: any;
+  }
+
+  /** The core set of properties associated with the policy. */
+  export interface V2Policy {
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Allows the customer to use their own words to record the purpose/context related to a policy. */
+    description?: string;
+    /** The subject attributes for whom the policy grants access. */
+    subject?: V2PolicySubject;
+    /** The resource attributes to which the policy grants access. */
+    resource?: V2PolicyResource;
+    /** Indicates pattern of rule, either 'time-based-conditions:once', 'time-based-conditions:weekly:all-day', or
+     *  'time-based-conditions:weekly:custom-hours'.
+     */
+    pattern?: string;
+    /** Additional access conditions associated with the policy. */
+    rule?: V2PolicyRule;
+    /** The policy ID. */
+    id?: string;
+    /** The href URL that links to the policies API by policy ID. */
+    href?: string;
+    control: ControlResponse;
+    /** The UTC timestamp when the policy was created. */
+    created_at?: string;
+    /** The iam ID of the entity that created the policy. */
+    created_by_id?: string;
+    /** The UTC timestamp when the policy was last modified. */
+    last_modified_at?: string;
+    /** The iam ID of the entity that last modified the policy. */
+    last_modified_by_id?: string;
+    /** The policy state, either 'deleted' or 'active'. */
+    state: string;
+    /** The optional last permit time of policy, when passing query parameter format=include_last_permit. */
+    last_permit_at?: string;
+    /** The optional count of times that policy has provided a permit, when passing query parameter
+     *  format=include_last_permit.
+     */
+    last_permit_frequency?: number;
+  }
+
+  /** A collection of policies. */
+  export interface V2PolicyCollection {
+    /** List of policies. */
+    policies?: V2Policy[];
   }
 
   /** Permission granted by the policy. */
-  export interface V2PolicyBaseControlGrant {
+  export interface V2PolicyGrant {
     /** A set of role cloud resource names (CRNs) granted by the policy. */
     roles: PolicyRole[];
   }
 
-  /** The resource attributes associated with a policy. */
-  export interface V2PolicyBaseResource {
-    /** List of resource attributes associated with policy/. */
-    attributes?: V2PolicyAttribute[];
+  /** The resource attributes to which the policy grants access. */
+  export interface V2PolicyResource {
+    /** List of resource attributes to which the policy grants access. */
+    attributes: V2PolicyResourceAttribute[];
+    /** Optional list of resource tags to which the policy grants access. */
+    tags?: V2PolicyResourceTag[];
   }
 
-  /** Additional access conditions associated with a policy. */
-  export interface V2PolicyBaseRule {}
+  /** Resource attribute to which the policy grants access. */
+  export interface V2PolicyResourceAttribute {
+    /** The name of a resource attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an rule or resource attribute; can be boolean or string for resource attribute. Can be a string
+     *  or an array of strings (e.g., array of days to permit access) for rule attribute.
+     */
+    value: any;
+  }
 
-  /** The subject attributes associated with a policy. */
-  export interface V2PolicyBaseSubject {
+  /** A tag associated with a resource. */
+  export interface V2PolicyResourceTag {
+    /** The name of an access management tag. */
+    key: string;
+    /** The value of an access management tag. */
+    value: string;
+    /** The operator of an access management tag. */
+    operator: string;
+  }
+
+  /** Additional access conditions associated with the policy. */
+  export interface V2PolicyRule {}
+
+  /** The subject attributes for whom the policy grants access. */
+  export interface V2PolicySubject {
     /** List of subject attributes associated with policy/. */
-    attributes?: V2PolicyAttribute[];
+    attributes: V2PolicySubjectAttribute[];
+  }
+
+  /** Subject attribute for whom the policy grants access. */
+  export interface V2PolicySubjectAttribute {
+    /** The name of a subject attribute, e.g., iam_id, access_group_id. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of the ID of the subject, e.g., service ID, access group ID, IAM ID. */
+    value: string;
   }
 
   /** An additional set of properties associated with a role. */
@@ -1879,23 +2053,23 @@ namespace IamPolicyManagementV1 {
     /** The role ID. Composed of hexadecimal characters. */
     id?: string;
     /** The display name of the role that is shown in the console. */
-    display_name?: string;
+    display_name: string;
     /** The description of the role. */
     description?: string;
     /** The actions of the role. Please refer to [IAM roles and
      *  actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
      */
-    actions?: string[];
+    actions: string[];
     /** The role Cloud Resource Name (CRN). Example CRN:
      *  'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
      */
     crn?: string;
     /** The name of the role that is used in the CRN. Can only be alphanumeric and has to be capitalized. */
-    name?: string;
+    name: string;
     /** The account GUID. */
-    account_id?: string;
+    account_id: string;
     /** The service name. */
-    service_name?: string;
+    service_name: string;
     /** The UTC timestamp when the role was created. */
     created_at?: string;
     /** The iam ID of the entity that created the role. */
@@ -1913,15 +2087,15 @@ namespace IamPolicyManagementV1 {
     /** The policy ID. */
     id?: string;
     /** The policy type; either 'access' or 'authorization'. */
-    type?: string;
+    type: string;
     /** Customer-defined description. */
     description?: string;
     /** The subjects associated with a policy. */
-    subjects?: PolicySubject[];
+    subjects: PolicySubject[];
     /** A set of role cloud resource names (CRNs) granted by the policy. */
-    roles?: PolicyRole[];
+    roles: PolicyRole[];
     /** The resources associated with a policy. */
-    resources?: PolicyResource[];
+    resources: PolicyResource[];
     /** The href link back to the policy. */
     href?: string;
     /** The UTC timestamp when the policy was created. */
@@ -1948,18 +2122,6 @@ namespace IamPolicyManagementV1 {
     attributes?: ResourceAttribute[];
     /** List of access management tags. */
     tags?: ResourceTag[];
-  }
-
-  /** A role associated with a policy. */
-  export interface PolicyRole {
-    /** The role Cloud Resource Name (CRN) granted by the policy. Example CRN:
-     *  'crn:v1:bluemix:public:iam::::role:Editor'.
-     */
-    role_id: string;
-    /** The display name of the role. */
-    display_name?: string;
-    /** The description of the role. */
-    description?: string;
   }
 
   /** The subject attribute values that must match in order for this policy to apply in a permission decision. */
@@ -1991,13 +2153,13 @@ namespace IamPolicyManagementV1 {
   /** A role resource. */
   export interface Role {
     /** The display name of the role that is shown in the console. */
-    display_name?: string;
+    display_name: string;
     /** The description of the role. */
     description?: string;
     /** The actions of the role. Please refer to [IAM roles and
      *  actions](https://cloud.ibm.com/docs/account?topic=account-iam-service-roles-actions).
      */
-    actions?: string[];
+    actions: string[];
     /** The role Cloud Resource Name (CRN). Example CRN:
      *  'crn:v1:ibmcloud:public:iam-access-management::a/exampleAccountId::customRole:ExampleRoleName'.
      */
@@ -2022,70 +2184,38 @@ namespace IamPolicyManagementV1 {
     value: string;
   }
 
-  /** The core set of properties associated with a policy. */
-  export interface V2Policy {
-    /** The policy ID. */
-    id?: string;
-    /** The policy type; either 'access' or 'authorization'. */
-    type: string;
-    /** Customer-defined description. */
-    description?: string;
-    /** The subject attributes associated with a policy. */
-    subject?: V2PolicyBaseSubject;
-    /** Specifies the type of access granted by the policy. */
-    control: V2PolicyBaseControl;
-    /** The resource attributes associated with a policy. */
-    resource?: V2PolicyBaseResource;
-    /** Indicates pattern of rule. */
-    pattern?: string;
-    /** Additional access conditions associated with a policy. */
-    rule?: V2PolicyBaseRule;
-    /** The href link back to the policy. */
-    href?: string;
-    /** The UTC timestamp when the policy was created. */
-    created_at?: string;
-    /** The iam ID of the entity that created the policy. */
-    created_by_id?: string;
-    /** The UTC timestamp when the policy was last modified. */
-    last_modified_at?: string;
-    /** The iam ID of the entity that last modified the policy. */
-    last_modified_by_id?: string;
-    /** The policy state. */
-    state?: string;
+  /** Specifies the type of access granted by the policy. */
+  export interface ControlResponseControl extends ControlResponse {
+    /** Permission granted by the policy. */
+    grant: V2PolicyGrant;
   }
 
-  /** Resource/subject attribute associated with policy attributes. */
-  export interface V2PolicyAttribute {
+  /** Specifies the type of access granted by the policy with additional role information. */
+  export interface ControlResponseControlWithTranslatedRoles extends ControlResponse {
+    /** Permission granted by the policy with translated roles and additional role information. */
+    grant: GrantWithTranslatedRoles;
+  }
+
+  /** Rule that specifies additional access granted (e.g., time-based condition). */
+  export interface V2PolicyRuleRuleAttribute extends V2PolicyRule {
     /** The name of an attribute. */
     key: string;
     /** The operator of an attribute. */
     operator: string;
-    /** The value of an attribute; can be array, boolean, string, or integer. */
+    /** The value of an rule or resource attribute; can be boolean or string for resource attribute. Can be a string
+     *  or an array of strings (e.g., array of days to permit access) for rule attribute.
+     */
     value: any;
   }
 
-  /** A collection of policies. */
-  export interface V2PolicyList {
-    /** List of policies. */
-    policies?: V2Policy[];
-  }
-
-  /** Resource/subject attribute associated with policy attributes. */
-  export interface V2PolicyBaseRuleV2PolicyAttribute extends V2PolicyBaseRule {
-    /** The name of an attribute. */
-    key: string;
-    /** The operator of an attribute. */
-    operator: string;
-    /** The value of an attribute; can be array, boolean, string, or integer. */
-    value: any;
-  }
-
-  /** Policy rule that has 2 to 10 conditions. */
-  export interface V2PolicyBaseRuleV2RuleWithConditions extends V2PolicyBaseRule {
+  /** Rule that specifies additional access granted (e.g., time-based condition) accross multiple conditions. */
+  export interface V2PolicyRuleRuleWithConditions extends V2PolicyRule {
     /** Operator to evalute conditions. */
     operator: string;
-    /** List of conditions to associated with a policy. Note that conditions can be nested up to 2 levels. */
-    conditions: V2PolicyAttribute[];
+    /** List of conditions associated with a policy, e.g., time-based-conditions that grant access over a certain
+     *  time period.
+     */
+    conditions: RuleAttribute[];
   }
 }
 

--- a/iam-policy-management/v1.ts
+++ b/iam-policy-management/v1.ts
@@ -926,6 +926,496 @@ class IamPolicyManagementV1 extends BaseService {
 
     return this.createRequest(parameters);
   }
+  /*************************
+   * v2Policies
+   ************************/
+
+  /**
+   * Get policies by attributes.
+   *
+   * Get policies and filter by attributes. While managing policies, you may want to retrieve policies in the account
+   * and filter by attribute values. This can be done through query parameters. Currently, only the following attributes
+   * are supported: account_id, iam_id, access_group_id, type, service_type, sort, format and state. account_id is a
+   * required query parameter. Only policies that have the specified attributes and that the caller has read access to
+   * are returned. If the caller does not have read access to any policies an empty array is returned.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.accountId - The account GUID in which the policies belong to.
+   * @param {string} [params.acceptLanguage] - Language code for translations
+   * * `default` - English
+   * * `de` -  German (Standard)
+   * * `en` - English
+   * * `es` - Spanish (Spain)
+   * * `fr` - French (Standard)
+   * * `it` - Italian (Standard)
+   * * `ja` - Japanese
+   * * `ko` - Korean
+   * * `pt-br` - Portuguese (Brazil)
+   * * `zh-cn` - Chinese (Simplified, PRC)
+   * * `zh-tw` - (Chinese, Taiwan).
+   * @param {string} [params.iamId] - Optional IAM ID used to identify the subject.
+   * @param {string} [params.accessGroupId] - Optional access group id.
+   * @param {string} [params.type] - Optional type of policy.
+   * @param {string} [params.serviceType] - Optional type of service.
+   * @param {string} [params.serviceName] - Optional name of service.
+   * @param {string} [params.serviceGroupId] - Optional ID of service group.
+   * @param {string} [params.format] - Include additional data per policy returned
+   * * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times
+   * it has done so
+   * * `display` - returns the list of all actions included in each of the policy roles and translations for all
+   * relevant fields.
+   * @param {string} [params.state] - The state of the policy.
+   * * `active` - returns active policies
+   * * `deleted` - returns non-active policies.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>>}
+   */
+  public v2ListPolicies(
+    params: IamPolicyManagementV1.V2ListPoliciesParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2PolicyList>> {
+    const _params = { ...params };
+    const _requiredParams = ['accountId'];
+    const _validParams = [
+      'accountId',
+      'acceptLanguage',
+      'iamId',
+      'accessGroupId',
+      'type',
+      'serviceType',
+      'serviceName',
+      'serviceGroupId',
+      'format',
+      'state',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'account_id': _params.accountId,
+      'iam_id': _params.iamId,
+      'access_group_id': _params.accessGroupId,
+      'type': _params.type,
+      'service_type': _params.serviceType,
+      'service_name': _params.serviceName,
+      'service_group_id': _params.serviceGroupId,
+      'format': _params.format,
+      'state': _params.state,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2ListPolicies'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Accept-Language': _params.acceptLanguage,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a policy.
+   *
+   * Creates a policy to grant access between a subject and a resource. Currently, there is one type of a v2/policy:
+   * **access**. A policy administrator might want to create an access policy which grants access to a user, service-id,
+   * or an access group.
+   *
+   * ### Access
+   *
+   * To create an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**, **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.`
+   * The rule field can either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`**
+   * with a combination **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field
+   * has a maximum of 2 levels of nested **`conditions`**. The operator for a rule can be used to specify a time based
+   * restriction (e.g., access only during business hours, during the Monday-Friday work week). For example, a policy
+   * can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset of
+   * account management services that includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
+   * Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.type - The policy type; either 'access' or 'authorization'.
+   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
+   * @param {string} [params.description] - Customer-defined description.
+   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
+   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
+   * @param {string} [params.pattern] - Indicates pattern of rule.
+   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {string} [params.acceptLanguage] - Language code for translations
+   * * `default` - English
+   * * `de` -  German (Standard)
+   * * `en` - English
+   * * `es` - Spanish (Spain)
+   * * `fr` - French (Standard)
+   * * `it` - Italian (Standard)
+   * * `ja` - Japanese
+   * * `ko` - Korean
+   * * `pt-br` - Portuguese (Brazil)
+   * * `zh-cn` - Chinese (Simplified, PRC)
+   * * `zh-tw` - (Chinese, Taiwan).
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2CreatePolicy(
+    params: IamPolicyManagementV1.V2CreatePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['type', 'control'];
+    const _validParams = [
+      'type',
+      'control',
+      'description',
+      'subject',
+      'resource',
+      'pattern',
+      'rule',
+      'acceptLanguage',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'type': _params.type,
+      'control': _params.control,
+      'description': _params.description,
+      'subject': _params.subject,
+      'resource': _params.resource,
+      'pattern': _params.pattern,
+      'rule': _params.rule,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2CreatePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies',
+        method: 'POST',
+        body,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Accept-Language': _params.acceptLanguage,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a policy.
+   *
+   * Update a policy to grant access between a subject and a resource. A policy administrator might want to update an
+   * existing policy.
+   *
+   * ### Access
+   *
+   * To update an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**,  or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can
+   * either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+   * **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+   * levels of nested **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g.,
+   * access only during business hours, during the Monday-Friday work week). For example, a policy can grant access
+   * Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
+   * request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {string} params.ifMatch - The revision number for updating a policy and must match the ETag value of the
+   * existing policy. The Etag can be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag
+   * response header.
+   * @param {string} params.type - The policy type; either 'access' or 'authorization'.
+   * @param {V2PolicyBaseControl} params.control - Specifies the type of access granted by the policy.
+   * @param {string} [params.description] - Customer-defined description.
+   * @param {V2PolicyBaseSubject} [params.subject] - The subject attributes associated with a policy.
+   * @param {V2PolicyBaseResource} [params.resource] - The resource attributes associated with a policy.
+   * @param {string} [params.pattern] - Indicates pattern of rule.
+   * @param {V2PolicyBaseRule} [params.rule] - Additional access conditions associated with a policy.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2UpdatePolicy(
+    params: IamPolicyManagementV1.V2UpdatePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId', 'ifMatch', 'type', 'control'];
+    const _validParams = [
+      'policyId',
+      'ifMatch',
+      'type',
+      'control',
+      'description',
+      'subject',
+      'resource',
+      'pattern',
+      'rule',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'type': _params.type,
+      'control': _params.control,
+      'description': _params.description,
+      'subject': _params.subject,
+      'resource': _params.resource,
+      'pattern': _params.pattern,
+      'rule': _params.rule,
+    };
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2UpdatePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
+        method: 'PUT',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Retrieve a policy by ID.
+   *
+   * Retrieve a policy by providing a policy ID.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>>}
+   */
+  public v2GetPolicy(
+    params: IamPolicyManagementV1.V2GetPolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.V2Policy>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2GetPolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a policy by ID.
+   *
+   * Delete a policy by providing a policy ID. A policy cannot be deleted if the subject ID contains a locked service
+   * ID. If the subject of the policy is a locked service-id, the request will fail.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.policyId - The policy ID.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>>}
+   */
+  public v2DeletePolicy(
+    params: IamPolicyManagementV1.V2DeletePolicyParams
+  ): Promise<IamPolicyManagementV1.Response<IamPolicyManagementV1.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['policyId'];
+    const _validParams = ['policyId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'policy_id': _params.policyId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamPolicyManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'v2DeletePolicy'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/policies/{policy_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(true, sdkHeaders, {}, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
 }
 
 /*************************
@@ -1215,9 +1705,174 @@ namespace IamPolicyManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `v2ListPolicies` operation. */
+  export interface V2ListPoliciesParams {
+    /** The account GUID in which the policies belong to. */
+    accountId: string;
+    /** Language code for translations
+     *  * `default` - English
+     *  * `de` -  German (Standard)
+     *  * `en` - English
+     *  * `es` - Spanish (Spain)
+     *  * `fr` - French (Standard)
+     *  * `it` - Italian (Standard)
+     *  * `ja` - Japanese
+     *  * `ko` - Korean
+     *  * `pt-br` - Portuguese (Brazil)
+     *  * `zh-cn` - Chinese (Simplified, PRC)
+     *  * `zh-tw` - (Chinese, Taiwan).
+     */
+    acceptLanguage?: string;
+    /** Optional IAM ID used to identify the subject. */
+    iamId?: string;
+    /** Optional access group id. */
+    accessGroupId?: string;
+    /** Optional type of policy. */
+    type?: V2ListPoliciesConstants.Type | string;
+    /** Optional type of service. */
+    serviceType?: V2ListPoliciesConstants.ServiceType | string;
+    /** Optional name of service. */
+    serviceName?: string;
+    /** Optional ID of service group. */
+    serviceGroupId?: string;
+    /** Include additional data per policy returned
+     *  * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of
+     *  times it has done so
+     *  * `display` - returns the list of all actions included in each of the policy roles and translations for all
+     *  relevant fields.
+     */
+    format?: V2ListPoliciesConstants.Format | string;
+    /** The state of the policy. * `active` - returns active policies * `deleted` - returns non-active policies. */
+    state?: V2ListPoliciesConstants.State | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `v2ListPolicies` operation. */
+  export namespace V2ListPoliciesConstants {
+    /** Optional type of policy. */
+    export enum Type {
+      ACCESS = 'access',
+      AUTHORIZATION = 'authorization',
+    }
+    /** Optional type of service. */
+    export enum ServiceType {
+      SERVICE = 'service',
+      PLATFORM_SERVICE = 'platform_service',
+    }
+    /** Include additional data per policy returned * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times it has done so * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant fields. */
+    export enum Format {
+      INCLUDE_LAST_PERMIT = 'include_last_permit',
+      DISPLAY = 'display',
+    }
+    /** The state of the policy. * `active` - returns active policies * `deleted` - returns non-active policies. */
+    export enum State {
+      ACTIVE = 'active',
+      DELETED = 'deleted',
+    }
+  }
+
+  /** Parameters for the `v2CreatePolicy` operation. */
+  export interface V2CreatePolicyParams {
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    /** Language code for translations
+     *  * `default` - English
+     *  * `de` -  German (Standard)
+     *  * `en` - English
+     *  * `es` - Spanish (Spain)
+     *  * `fr` - French (Standard)
+     *  * `it` - Italian (Standard)
+     *  * `ja` - Japanese
+     *  * `ko` - Korean
+     *  * `pt-br` - Portuguese (Brazil)
+     *  * `zh-cn` - Chinese (Simplified, PRC)
+     *  * `zh-tw` - (Chinese, Taiwan).
+     */
+    acceptLanguage?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2UpdatePolicy` operation. */
+  export interface V2UpdatePolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    /** The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can
+     *  be retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag response header.
+     */
+    ifMatch: string;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2GetPolicy` operation. */
+  export interface V2GetPolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `v2DeletePolicy` operation. */
+  export interface V2DeletePolicyParams {
+    /** The policy ID. */
+    policyId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /*************************
    * model interfaces
    ************************/
+
+  /** Specifies the type of access granted by the policy. */
+  export interface V2PolicyBaseControl {
+    /** Permission granted by the policy. */
+    grant: V2PolicyBaseControlGrant;
+  }
+
+  /** Permission granted by the policy. */
+  export interface V2PolicyBaseControlGrant {
+    /** A set of role cloud resource names (CRNs) granted by the policy. */
+    roles: PolicyRole[];
+  }
+
+  /** The resource attributes associated with a policy. */
+  export interface V2PolicyBaseResource {
+    /** List of resource attributes associated with policy/. */
+    attributes?: V2PolicyAttribute[];
+  }
+
+  /** Additional access conditions associated with a policy. */
+  export interface V2PolicyBaseRule {}
+
+  /** The subject attributes associated with a policy. */
+  export interface V2PolicyBaseSubject {
+    /** List of subject attributes associated with policy/. */
+    attributes?: V2PolicyAttribute[];
+  }
 
   /** An additional set of properties associated with a role. */
   export interface CustomRole {
@@ -1365,6 +2020,72 @@ namespace IamPolicyManagementV1 {
     name: string;
     /** The value of an attribute. */
     value: string;
+  }
+
+  /** The core set of properties associated with a policy. */
+  export interface V2Policy {
+    /** The policy ID. */
+    id?: string;
+    /** The policy type; either 'access' or 'authorization'. */
+    type: string;
+    /** Customer-defined description. */
+    description?: string;
+    /** The subject attributes associated with a policy. */
+    subject?: V2PolicyBaseSubject;
+    /** Specifies the type of access granted by the policy. */
+    control: V2PolicyBaseControl;
+    /** The resource attributes associated with a policy. */
+    resource?: V2PolicyBaseResource;
+    /** Indicates pattern of rule. */
+    pattern?: string;
+    /** Additional access conditions associated with a policy. */
+    rule?: V2PolicyBaseRule;
+    /** The href link back to the policy. */
+    href?: string;
+    /** The UTC timestamp when the policy was created. */
+    created_at?: string;
+    /** The iam ID of the entity that created the policy. */
+    created_by_id?: string;
+    /** The UTC timestamp when the policy was last modified. */
+    last_modified_at?: string;
+    /** The iam ID of the entity that last modified the policy. */
+    last_modified_by_id?: string;
+    /** The policy state. */
+    state?: string;
+  }
+
+  /** Resource/subject attribute associated with policy attributes. */
+  export interface V2PolicyAttribute {
+    /** The name of an attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an attribute; can be array, boolean, string, or integer. */
+    value: any;
+  }
+
+  /** A collection of policies. */
+  export interface V2PolicyList {
+    /** List of policies. */
+    policies?: V2Policy[];
+  }
+
+  /** Resource/subject attribute associated with policy attributes. */
+  export interface V2PolicyBaseRuleV2PolicyAttribute extends V2PolicyBaseRule {
+    /** The name of an attribute. */
+    key: string;
+    /** The operator of an attribute. */
+    operator: string;
+    /** The value of an attribute; can be array, boolean, string, or integer. */
+    value: any;
+  }
+
+  /** Policy rule that has 2 to 10 conditions. */
+  export interface V2PolicyBaseRuleV2RuleWithConditions extends V2PolicyBaseRule {
+    /** Operator to evalute conditions. */
+    operator: string;
+    /** List of conditions to associated with a policy. Note that conditions can be nested up to 2 levels. */
+    conditions: V2PolicyAttribute[];
   }
 }
 

--- a/test/integration/iam-policy-management.v1.test.js
+++ b/test/integration/iam-policy-management.v1.test.js
@@ -103,18 +103,18 @@ describe('IamPolicyManagementV1_integration', () => {
   const v2PolicyResource = {
     attributes: [v2PolicyResourceAccountAttribute, v2PolicyResourceServiceAttribute],
   };
-  const v2PolicyControl = {
+  const control = {
     grant: {
       roles: policyRoles,
     },
   };
-  const v2PolicyRule = {
+  const rule = {
     operator: 'and',
     conditions: [
       {
         key: '{{environment.attributes.day_of_week}}',
         operator: 'dayOfWeekAnyOf',
-        value: [1, 2, 3, 4, 5],
+        value: ['1+00:00', '2+00:00', '3+00:00', '4+00:00', '5+00:00'],
       },
       {
         key: '{{environment.attributes.current_time}}',
@@ -128,7 +128,7 @@ describe('IamPolicyManagementV1_integration', () => {
       },
     ],
   };
-  const v2PolicyPattern = 'time-based-restrictions:weekly';
+  const pattern = 'time-based-conditions:weekly:custom-hours';
 
   let testCustomRoleId;
   let testCustomRoleEtag;
@@ -232,7 +232,7 @@ describe('IamPolicyManagementV1_integration', () => {
 
       let response;
       try {
-        response = await service.updatePolicy(params);
+        response = await service.replacePolicy(params);
       } catch (err) {
         console.warn(err);
       }
@@ -262,7 +262,7 @@ describe('IamPolicyManagementV1_integration', () => {
 
       let response;
       try {
-        response = await service.patchPolicy(params);
+        response = await service.updatePolicyState(params);
       } catch (err) {
         console.warn(err);
       }
@@ -361,10 +361,10 @@ describe('IamPolicyManagementV1_integration', () => {
       const params = {
         type: 'access',
         subject: v2PolicySubject,
-        control: v2PolicyControl,
+        control,
         resource: v2PolicyResource,
-        rule: v2PolicyRule,
-        pattern: v2PolicyPattern,
+        rule,
+        pattern,
       };
 
       // ensure resource account value is defined
@@ -372,7 +372,7 @@ describe('IamPolicyManagementV1_integration', () => {
 
       let response;
       try {
-        response = await service.v2CreatePolicy(params);
+        response = await service.createV2Policy(params);
       } catch (err) {
         console.warn(err);
       }
@@ -383,7 +383,7 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result).toBeDefined();
       expect(result.type).toEqual(policyType);
       expect(result.subject).toEqual(v2PolicySubject);
-      expect(result.control).toEqual(v2PolicyControl);
+      expect(result.control).toEqual(control);
       expect(result.resource).toEqual(v2PolicyResource);
 
       testV2PolicyId = result.id;
@@ -393,12 +393,12 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(testPolicyId).toBeDefined();
 
       const params = {
-        policyId: testV2PolicyId,
+        id: testV2PolicyId,
       };
 
       let response;
       try {
-        response = await service.v2GetPolicy(params);
+        response = await service.getV2Policy(params);
       } catch (err) {
         console.warn(err);
       }
@@ -410,7 +410,7 @@ describe('IamPolicyManagementV1_integration', () => {
       expect(result.id).toEqual(testV2PolicyId);
       expect(result.type).toEqual(policyType);
       expect(result.subject).toEqual(v2PolicySubject);
-      expect(result.control).toEqual(v2PolicyControl);
+      expect(result.control).toEqual(control);
       expect(result.resource).toEqual(v2PolicyResource);
 
       testV2PolicyETag = response.headers.etag;
@@ -431,19 +431,19 @@ describe('IamPolicyManagementV1_integration', () => {
       };
 
       const params = {
-        policyId: testV2PolicyId,
+        id: testV2PolicyId,
         ifMatch: testV2PolicyETag,
         type: 'access',
         subject: v2PolicySubject,
         control: updatedControl,
         resource: v2PolicyResource,
-        rule: v2PolicyRule,
-        pattern: v2PolicyPattern,
+        rule,
+        pattern,
       };
 
       let response;
       try {
-        response = await service.v2UpdatePolicy(params);
+        response = await service.replaceV2Policy(params);
       } catch (err) {
         console.warn(err);
       }
@@ -469,7 +469,7 @@ describe('IamPolicyManagementV1_integration', () => {
 
       let response;
       try {
-        response = await service.v2ListPolicies(params);
+        response = await service.listV2Policies(params);
       } catch (err) {
         console.warn(err);
       }
@@ -500,7 +500,7 @@ describe('IamPolicyManagementV1_integration', () => {
 
       let response;
       try {
-        response = await service.v2ListPolicies(params);
+        response = await service.listV2Policies(params);
       } catch (err) {
         console.warn(err);
       }
@@ -520,12 +520,12 @@ describe('IamPolicyManagementV1_integration', () => {
 
         if (policy.id === testV2PolicyId || createdAt < fiveMinutesAgo) {
           const params = {
-            policyId: policy.id,
+            id: policy.id,
           };
 
           let response;
           try {
-            response = await service.v2DeletePolicy(params);
+            response = await service.deleteV2Policy(params);
           } catch (err) {
             console.warn(err);
           }
@@ -608,12 +608,14 @@ describe('IamPolicyManagementV1_integration', () => {
         roleId: testCustomRoleId,
         ifMatch: testCustomRoleEtag,
         description: updCustomRoleDescription,
+        displayName: testCustomRoleDisplayName,
+        actions: testCustomRoleActions,
         headers: { 'transaction-Id': `SDKNode-${testUniqueId}` },
       };
 
       let response;
       try {
-        response = await service.updateRole(params);
+        response = await service.replaceRole(params);
       } catch (err) {
         console.warn(err);
       }

--- a/test/unit/iam-policy-management.v1.test.js
+++ b/test/unit/iam-policy-management.v1.test.js
@@ -1231,4 +1231,586 @@ describe('IamPolicyManagementV1', () => {
       });
     });
   });
+
+  describe('v2ListPolicies', () => {
+    describe('positive tests', () => {
+      function __v2ListPoliciesTest() {
+        // Construct the params object for operation v2ListPolicies
+        const accountId = 'testString';
+        const acceptLanguage = 'default';
+        const iamId = 'testString';
+        const accessGroupId = 'testString';
+        const type = 'access';
+        const serviceType = 'service';
+        const serviceName = 'testString';
+        const serviceGroupId = 'testString';
+        const format = 'include_last_permit';
+        const state = 'active';
+        const v2ListPoliciesParams = {
+          accountId,
+          acceptLanguage,
+          iamId,
+          accessGroupId,
+          type,
+          serviceType,
+          serviceName,
+          serviceGroupId,
+          format,
+          state,
+        };
+
+        const v2ListPoliciesResult = iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2ListPoliciesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
+        expect(mockRequestOptions.qs.account_id).toEqual(accountId);
+        expect(mockRequestOptions.qs.iam_id).toEqual(iamId);
+        expect(mockRequestOptions.qs.access_group_id).toEqual(accessGroupId);
+        expect(mockRequestOptions.qs.type).toEqual(type);
+        expect(mockRequestOptions.qs.service_type).toEqual(serviceType);
+        expect(mockRequestOptions.qs.service_name).toEqual(serviceName);
+        expect(mockRequestOptions.qs.service_group_id).toEqual(serviceGroupId);
+        expect(mockRequestOptions.qs.format).toEqual(format);
+        expect(mockRequestOptions.qs.state).toEqual(state);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2ListPoliciesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2ListPoliciesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2ListPoliciesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const accountId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2ListPoliciesParams = {
+          accountId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2ListPolicies({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2ListPolicies();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2CreatePolicy', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // PolicyRole
+      const policyRoleModel = {
+        role_id: 'testString',
+      };
+
+      // V2PolicyBaseControlGrant
+      const v2PolicyBaseControlGrantModel = {
+        roles: [policyRoleModel],
+      };
+
+      // V2PolicyBaseControl
+      const v2PolicyBaseControlModel = {
+        grant: v2PolicyBaseControlGrantModel,
+      };
+
+      // V2PolicyAttribute
+      const v2PolicyAttributeModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      // V2PolicyBaseSubject
+      const v2PolicyBaseSubjectModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseResource
+      const v2PolicyBaseResourceModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseRuleV2PolicyAttribute
+      const v2PolicyBaseRuleModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      function __v2CreatePolicyTest() {
+        // Construct the params object for operation v2CreatePolicy
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const description = 'testString';
+        const subject = v2PolicyBaseSubjectModel;
+        const resource = v2PolicyBaseResourceModel;
+        const pattern = 'testString';
+        const rule = v2PolicyBaseRuleModel;
+        const acceptLanguage = 'default';
+        const v2CreatePolicyParams = {
+          type,
+          control,
+          description,
+          subject,
+          resource,
+          pattern,
+          rule,
+          acceptLanguage,
+        };
+
+        const v2CreatePolicyResult = iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2CreatePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.subject).toEqual(subject);
+        expect(mockRequestOptions.body.resource).toEqual(resource);
+        expect(mockRequestOptions.body.pattern).toEqual(pattern);
+        expect(mockRequestOptions.body.rule).toEqual(rule);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2CreatePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2CreatePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2CreatePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2CreatePolicyParams = {
+          type,
+          control,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2CreatePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2CreatePolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2UpdatePolicy', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // PolicyRole
+      const policyRoleModel = {
+        role_id: 'testString',
+      };
+
+      // V2PolicyBaseControlGrant
+      const v2PolicyBaseControlGrantModel = {
+        roles: [policyRoleModel],
+      };
+
+      // V2PolicyBaseControl
+      const v2PolicyBaseControlModel = {
+        grant: v2PolicyBaseControlGrantModel,
+      };
+
+      // V2PolicyAttribute
+      const v2PolicyAttributeModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      // V2PolicyBaseSubject
+      const v2PolicyBaseSubjectModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseResource
+      const v2PolicyBaseResourceModel = {
+        attributes: [v2PolicyAttributeModel],
+      };
+
+      // V2PolicyBaseRuleV2PolicyAttribute
+      const v2PolicyBaseRuleModel = {
+        key: 'testString',
+        operator: 'testString',
+        value: 'testString',
+      };
+
+      function __v2UpdatePolicyTest() {
+        // Construct the params object for operation v2UpdatePolicy
+        const policyId = 'testString';
+        const ifMatch = 'testString';
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const description = 'testString';
+        const subject = v2PolicyBaseSubjectModel;
+        const resource = v2PolicyBaseResourceModel;
+        const pattern = 'testString';
+        const rule = v2PolicyBaseRuleModel;
+        const v2UpdatePolicyParams = {
+          policyId,
+          ifMatch,
+          type,
+          control,
+          description,
+          subject,
+          resource,
+          pattern,
+          rule,
+        };
+
+        const v2UpdatePolicyResult = iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2UpdatePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'PUT');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.subject).toEqual(subject);
+        expect(mockRequestOptions.body.resource).toEqual(resource);
+        expect(mockRequestOptions.body.pattern).toEqual(pattern);
+        expect(mockRequestOptions.body.rule).toEqual(rule);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2UpdatePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2UpdatePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2UpdatePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const ifMatch = 'testString';
+        const type = 'testString';
+        const control = v2PolicyBaseControlModel;
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2UpdatePolicyParams = {
+          policyId,
+          ifMatch,
+          type,
+          control,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2UpdatePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2UpdatePolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2GetPolicy', () => {
+    describe('positive tests', () => {
+      function __v2GetPolicyTest() {
+        // Construct the params object for operation v2GetPolicy
+        const policyId = 'testString';
+        const v2GetPolicyParams = {
+          policyId,
+        };
+
+        const v2GetPolicyResult = iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2GetPolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2GetPolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2GetPolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2GetPolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2GetPolicyParams = {
+          policyId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2GetPolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2GetPolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('v2DeletePolicy', () => {
+    describe('positive tests', () => {
+      function __v2DeletePolicyTest() {
+        // Construct the params object for operation v2DeletePolicy
+        const policyId = 'testString';
+        const v2DeletePolicyParams = {
+          policyId,
+        };
+
+        const v2DeletePolicyResult = iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+
+        // all methods should return a Promise
+        expectToBePromise(v2DeletePolicyResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __v2DeletePolicyTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.enableRetries();
+        __v2DeletePolicyTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamPolicyManagementService.disableRetries();
+        __v2DeletePolicyTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const policyId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const v2DeletePolicyParams = {
+          policyId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2DeletePolicy({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamPolicyManagementService.v2DeletePolicy();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
 });

--- a/test/unit/iam-policy-management.v1.test.js
+++ b/test/unit/iam-policy-management.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -370,7 +370,7 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('updatePolicy', () => {
+  describe('replacePolicy', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
@@ -410,8 +410,8 @@ describe('IamPolicyManagementV1', () => {
         tags: [resourceTagModel],
       };
 
-      function __updatePolicyTest() {
-        // Construct the params object for operation updatePolicy
+      function __replacePolicyTest() {
+        // Construct the params object for operation replacePolicy
         const policyId = 'testString';
         const ifMatch = 'testString';
         const type = 'testString';
@@ -419,7 +419,7 @@ describe('IamPolicyManagementV1', () => {
         const roles = [policyRoleModel];
         const resources = [policyResourceModel];
         const description = 'testString';
-        const updatePolicyParams = {
+        const replacePolicyParams = {
           policyId,
           ifMatch,
           type,
@@ -429,10 +429,10 @@ describe('IamPolicyManagementV1', () => {
           description,
         };
 
-        const updatePolicyResult = iamPolicyManagementService.updatePolicy(updatePolicyParams);
+        const replacePolicyResult = iamPolicyManagementService.replacePolicy(replacePolicyParams);
 
         // all methods should return a Promise
-        expectToBePromise(updatePolicyResult);
+        expectToBePromise(replacePolicyResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -454,17 +454,17 @@ describe('IamPolicyManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __updatePolicyTest();
+        __replacePolicyTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __updatePolicyTest();
+        __replacePolicyTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __updatePolicyTest();
+        __replacePolicyTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -477,7 +477,7 @@ describe('IamPolicyManagementV1', () => {
         const resources = [policyResourceModel];
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const updatePolicyParams = {
+        const replacePolicyParams = {
           policyId,
           ifMatch,
           type,
@@ -490,7 +490,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.updatePolicy(updatePolicyParams);
+        iamPolicyManagementService.replacePolicy(replacePolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -499,7 +499,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.updatePolicy({});
+          await iamPolicyManagementService.replacePolicy({});
         } catch (e) {
           err = e;
         }
@@ -510,7 +510,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.updatePolicy();
+          await iamPolicyManagementService.replacePolicy();
         } catch (e) {
           err = e;
         }
@@ -688,23 +688,23 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('patchPolicy', () => {
+  describe('updatePolicyState', () => {
     describe('positive tests', () => {
-      function __patchPolicyTest() {
-        // Construct the params object for operation patchPolicy
+      function __updatePolicyStateTest() {
+        // Construct the params object for operation updatePolicyState
         const policyId = 'testString';
         const ifMatch = 'testString';
         const state = 'active';
-        const patchPolicyParams = {
+        const updatePolicyStateParams = {
           policyId,
           ifMatch,
           state,
         };
 
-        const patchPolicyResult = iamPolicyManagementService.patchPolicy(patchPolicyParams);
+        const updatePolicyStateResult = iamPolicyManagementService.updatePolicyState(updatePolicyStateParams);
 
         // all methods should return a Promise
-        expectToBePromise(patchPolicyResult);
+        expectToBePromise(updatePolicyStateResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -722,17 +722,17 @@ describe('IamPolicyManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __patchPolicyTest();
+        __updatePolicyStateTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __patchPolicyTest();
+        __updatePolicyStateTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __patchPolicyTest();
+        __updatePolicyStateTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -741,7 +741,7 @@ describe('IamPolicyManagementV1', () => {
         const ifMatch = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const patchPolicyParams = {
+        const updatePolicyStateParams = {
           policyId,
           ifMatch,
           headers: {
@@ -750,7 +750,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.patchPolicy(patchPolicyParams);
+        iamPolicyManagementService.updatePolicyState(updatePolicyStateParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -759,7 +759,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.patchPolicy({});
+          await iamPolicyManagementService.updatePolicyState({});
         } catch (e) {
           err = e;
         }
@@ -770,7 +770,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.patchPolicy();
+          await iamPolicyManagementService.updatePolicyState();
         } catch (e) {
           err = e;
         }
@@ -966,27 +966,27 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('updateRole', () => {
+  describe('replaceRole', () => {
     describe('positive tests', () => {
-      function __updateRoleTest() {
-        // Construct the params object for operation updateRole
+      function __replaceRoleTest() {
+        // Construct the params object for operation replaceRole
         const roleId = 'testString';
         const ifMatch = 'testString';
         const displayName = 'testString';
-        const description = 'testString';
         const actions = ['testString'];
-        const updateRoleParams = {
+        const description = 'testString';
+        const replaceRoleParams = {
           roleId,
           ifMatch,
           displayName,
-          description,
           actions,
+          description,
         };
 
-        const updateRoleResult = iamPolicyManagementService.updateRole(updateRoleParams);
+        const replaceRoleResult = iamPolicyManagementService.replaceRole(replaceRoleParams);
 
         // all methods should return a Promise
-        expectToBePromise(updateRoleResult);
+        expectToBePromise(replaceRoleResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -999,42 +999,46 @@ describe('IamPolicyManagementV1', () => {
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'If-Match', ifMatch);
         expect(mockRequestOptions.body.display_name).toEqual(displayName);
-        expect(mockRequestOptions.body.description).toEqual(description);
         expect(mockRequestOptions.body.actions).toEqual(actions);
+        expect(mockRequestOptions.body.description).toEqual(description);
         expect(mockRequestOptions.path.role_id).toEqual(roleId);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __updateRoleTest();
+        __replaceRoleTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __updateRoleTest();
+        __replaceRoleTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __updateRoleTest();
+        __replaceRoleTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const roleId = 'testString';
         const ifMatch = 'testString';
+        const displayName = 'testString';
+        const actions = ['testString'];
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const updateRoleParams = {
+        const replaceRoleParams = {
           roleId,
           ifMatch,
+          displayName,
+          actions,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.updateRole(updateRoleParams);
+        iamPolicyManagementService.replaceRole(replaceRoleParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1043,7 +1047,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.updateRole({});
+          await iamPolicyManagementService.replaceRole({});
         } catch (e) {
           err = e;
         }
@@ -1054,7 +1058,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.updateRole();
+          await iamPolicyManagementService.replaceRole();
         } catch (e) {
           err = e;
         }
@@ -1232,10 +1236,10 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('v2ListPolicies', () => {
+  describe('listV2Policies', () => {
     describe('positive tests', () => {
-      function __v2ListPoliciesTest() {
-        // Construct the params object for operation v2ListPolicies
+      function __listV2PoliciesTest() {
+        // Construct the params object for operation listV2Policies
         const accountId = 'testString';
         const acceptLanguage = 'default';
         const iamId = 'testString';
@@ -1246,7 +1250,7 @@ describe('IamPolicyManagementV1', () => {
         const serviceGroupId = 'testString';
         const format = 'include_last_permit';
         const state = 'active';
-        const v2ListPoliciesParams = {
+        const listV2PoliciesParams = {
           accountId,
           acceptLanguage,
           iamId,
@@ -1259,10 +1263,10 @@ describe('IamPolicyManagementV1', () => {
           state,
         };
 
-        const v2ListPoliciesResult = iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+        const listV2PoliciesResult = iamPolicyManagementService.listV2Policies(listV2PoliciesParams);
 
         // all methods should return a Promise
-        expectToBePromise(v2ListPoliciesResult);
+        expectToBePromise(listV2PoliciesResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -1287,17 +1291,17 @@ describe('IamPolicyManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __v2ListPoliciesTest();
+        __listV2PoliciesTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __v2ListPoliciesTest();
+        __listV2PoliciesTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __v2ListPoliciesTest();
+        __listV2PoliciesTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1305,7 +1309,7 @@ describe('IamPolicyManagementV1', () => {
         const accountId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const v2ListPoliciesParams = {
+        const listV2PoliciesParams = {
           accountId,
           headers: {
             Accept: userAccept,
@@ -1313,7 +1317,7 @@ describe('IamPolicyManagementV1', () => {
           },
         };
 
-        iamPolicyManagementService.v2ListPolicies(v2ListPoliciesParams);
+        iamPolicyManagementService.listV2Policies(listV2PoliciesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1322,7 +1326,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2ListPolicies({});
+          await iamPolicyManagementService.listV2Policies({});
         } catch (e) {
           err = e;
         }
@@ -1333,7 +1337,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2ListPolicies();
+          await iamPolicyManagementService.listV2Policies();
         } catch (e) {
           err = e;
         }
@@ -1343,7 +1347,7 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('v2CreatePolicy', () => {
+  describe('createV2Policy', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
@@ -1352,53 +1356,68 @@ describe('IamPolicyManagementV1', () => {
         role_id: 'testString',
       };
 
-      // V2PolicyBaseControlGrant
-      const v2PolicyBaseControlGrantModel = {
+      // V2PolicyGrant
+      const v2PolicyGrantModel = {
         roles: [policyRoleModel],
       };
 
-      // V2PolicyBaseControl
-      const v2PolicyBaseControlModel = {
-        grant: v2PolicyBaseControlGrantModel,
+      // Control
+      const controlModel = {
+        grant: v2PolicyGrantModel,
       };
 
-      // V2PolicyAttribute
-      const v2PolicyAttributeModel = {
+      // V2PolicySubjectAttribute
+      const v2PolicySubjectAttributeModel = {
         key: 'testString',
-        operator: 'testString',
+        operator: 'stringEquals',
         value: 'testString',
       };
 
-      // V2PolicyBaseSubject
-      const v2PolicyBaseSubjectModel = {
-        attributes: [v2PolicyAttributeModel],
+      // V2PolicySubject
+      const v2PolicySubjectModel = {
+        attributes: [v2PolicySubjectAttributeModel],
       };
 
-      // V2PolicyBaseResource
-      const v2PolicyBaseResourceModel = {
-        attributes: [v2PolicyAttributeModel],
-      };
-
-      // V2PolicyBaseRuleV2PolicyAttribute
-      const v2PolicyBaseRuleModel = {
+      // V2PolicyResourceAttribute
+      const v2PolicyResourceAttributeModel = {
         key: 'testString',
-        operator: 'testString',
+        operator: 'stringEquals',
         value: 'testString',
       };
 
-      function __v2CreatePolicyTest() {
-        // Construct the params object for operation v2CreatePolicy
-        const type = 'testString';
-        const control = v2PolicyBaseControlModel;
+      // V2PolicyResourceTag
+      const v2PolicyResourceTagModel = {
+        key: 'testString',
+        value: 'testString',
+        operator: 'stringEquals',
+      };
+
+      // V2PolicyResource
+      const v2PolicyResourceModel = {
+        attributes: [v2PolicyResourceAttributeModel],
+        tags: [v2PolicyResourceTagModel],
+      };
+
+      // V2PolicyRuleRuleAttribute
+      const v2PolicyRuleModel = {
+        key: 'testString',
+        operator: 'timeLessThan',
+        value: 'testString',
+      };
+
+      function __createV2PolicyTest() {
+        // Construct the params object for operation createV2Policy
+        const control = controlModel;
+        const type = 'access';
         const description = 'testString';
-        const subject = v2PolicyBaseSubjectModel;
-        const resource = v2PolicyBaseResourceModel;
+        const subject = v2PolicySubjectModel;
+        const resource = v2PolicyResourceModel;
         const pattern = 'testString';
-        const rule = v2PolicyBaseRuleModel;
+        const rule = v2PolicyRuleModel;
         const acceptLanguage = 'default';
-        const v2CreatePolicyParams = {
-          type,
+        const createV2PolicyParams = {
           control,
+          type,
           description,
           subject,
           resource,
@@ -1407,10 +1426,10 @@ describe('IamPolicyManagementV1', () => {
           acceptLanguage,
         };
 
-        const v2CreatePolicyResult = iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+        const createV2PolicyResult = iamPolicyManagementService.createV2Policy(createV2PolicyParams);
 
         // all methods should return a Promise
-        expectToBePromise(v2CreatePolicyResult);
+        expectToBePromise(createV2PolicyResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -1422,8 +1441,8 @@ describe('IamPolicyManagementV1', () => {
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
-        expect(mockRequestOptions.body.type).toEqual(type);
         expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.type).toEqual(type);
         expect(mockRequestOptions.body.description).toEqual(description);
         expect(mockRequestOptions.body.subject).toEqual(subject);
         expect(mockRequestOptions.body.resource).toEqual(resource);
@@ -1433,35 +1452,35 @@ describe('IamPolicyManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __v2CreatePolicyTest();
+        __createV2PolicyTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __v2CreatePolicyTest();
+        __createV2PolicyTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __v2CreatePolicyTest();
+        __createV2PolicyTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const type = 'testString';
-        const control = v2PolicyBaseControlModel;
+        const control = controlModel;
+        const type = 'access';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const v2CreatePolicyParams = {
-          type,
+        const createV2PolicyParams = {
           control,
+          type,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyParams);
+        iamPolicyManagementService.createV2Policy(createV2PolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1470,7 +1489,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2CreatePolicy({});
+          await iamPolicyManagementService.createV2Policy({});
         } catch (e) {
           err = e;
         }
@@ -1481,7 +1500,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2CreatePolicy();
+          await iamPolicyManagementService.createV2Policy();
         } catch (e) {
           err = e;
         }
@@ -1491,7 +1510,7 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('v2UpdatePolicy', () => {
+  describe('replaceV2Policy', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
@@ -1500,56 +1519,71 @@ describe('IamPolicyManagementV1', () => {
         role_id: 'testString',
       };
 
-      // V2PolicyBaseControlGrant
-      const v2PolicyBaseControlGrantModel = {
+      // V2PolicyGrant
+      const v2PolicyGrantModel = {
         roles: [policyRoleModel],
       };
 
-      // V2PolicyBaseControl
-      const v2PolicyBaseControlModel = {
-        grant: v2PolicyBaseControlGrantModel,
+      // Control
+      const controlModel = {
+        grant: v2PolicyGrantModel,
       };
 
-      // V2PolicyAttribute
-      const v2PolicyAttributeModel = {
+      // V2PolicySubjectAttribute
+      const v2PolicySubjectAttributeModel = {
         key: 'testString',
-        operator: 'testString',
+        operator: 'stringEquals',
         value: 'testString',
       };
 
-      // V2PolicyBaseSubject
-      const v2PolicyBaseSubjectModel = {
-        attributes: [v2PolicyAttributeModel],
+      // V2PolicySubject
+      const v2PolicySubjectModel = {
+        attributes: [v2PolicySubjectAttributeModel],
       };
 
-      // V2PolicyBaseResource
-      const v2PolicyBaseResourceModel = {
-        attributes: [v2PolicyAttributeModel],
-      };
-
-      // V2PolicyBaseRuleV2PolicyAttribute
-      const v2PolicyBaseRuleModel = {
+      // V2PolicyResourceAttribute
+      const v2PolicyResourceAttributeModel = {
         key: 'testString',
-        operator: 'testString',
+        operator: 'stringEquals',
         value: 'testString',
       };
 
-      function __v2UpdatePolicyTest() {
-        // Construct the params object for operation v2UpdatePolicy
-        const policyId = 'testString';
+      // V2PolicyResourceTag
+      const v2PolicyResourceTagModel = {
+        key: 'testString',
+        value: 'testString',
+        operator: 'stringEquals',
+      };
+
+      // V2PolicyResource
+      const v2PolicyResourceModel = {
+        attributes: [v2PolicyResourceAttributeModel],
+        tags: [v2PolicyResourceTagModel],
+      };
+
+      // V2PolicyRuleRuleAttribute
+      const v2PolicyRuleModel = {
+        key: 'testString',
+        operator: 'timeLessThan',
+        value: 'testString',
+      };
+
+      function __replaceV2PolicyTest() {
+        // Construct the params object for operation replaceV2Policy
+        const id = 'testString';
         const ifMatch = 'testString';
-        const type = 'testString';
-        const control = v2PolicyBaseControlModel;
+        const control = controlModel;
+        const type = 'access';
         const description = 'testString';
-        const subject = v2PolicyBaseSubjectModel;
-        const resource = v2PolicyBaseResourceModel;
+        const subject = v2PolicySubjectModel;
+        const resource = v2PolicyResourceModel;
         const pattern = 'testString';
-        const rule = v2PolicyBaseRuleModel;
-        const v2UpdatePolicyParams = {
-          policyId,
+        const rule = v2PolicyRuleModel;
+        const replaceV2PolicyParams = {
+          id,
           ifMatch,
-          type,
           control,
+          type,
           description,
           subject,
           resource,
@@ -1557,66 +1591,66 @@ describe('IamPolicyManagementV1', () => {
           rule,
         };
 
-        const v2UpdatePolicyResult = iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+        const replaceV2PolicyResult = iamPolicyManagementService.replaceV2Policy(replaceV2PolicyParams);
 
         // all methods should return a Promise
-        expectToBePromise(v2UpdatePolicyResult);
+        expectToBePromise(replaceV2PolicyResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'If-Match', ifMatch);
-        expect(mockRequestOptions.body.type).toEqual(type);
         expect(mockRequestOptions.body.control).toEqual(control);
+        expect(mockRequestOptions.body.type).toEqual(type);
         expect(mockRequestOptions.body.description).toEqual(description);
         expect(mockRequestOptions.body.subject).toEqual(subject);
         expect(mockRequestOptions.body.resource).toEqual(resource);
         expect(mockRequestOptions.body.pattern).toEqual(pattern);
         expect(mockRequestOptions.body.rule).toEqual(rule);
-        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+        expect(mockRequestOptions.path.id).toEqual(id);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __v2UpdatePolicyTest();
+        __replaceV2PolicyTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __v2UpdatePolicyTest();
+        __replaceV2PolicyTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __v2UpdatePolicyTest();
+        __replaceV2PolicyTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const policyId = 'testString';
+        const id = 'testString';
         const ifMatch = 'testString';
-        const type = 'testString';
-        const control = v2PolicyBaseControlModel;
+        const control = controlModel;
+        const type = 'access';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const v2UpdatePolicyParams = {
-          policyId,
+        const replaceV2PolicyParams = {
+          id,
           ifMatch,
-          type,
           control,
+          type,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyParams);
+        iamPolicyManagementService.replaceV2Policy(replaceV2PolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1625,7 +1659,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2UpdatePolicy({});
+          await iamPolicyManagementService.replaceV2Policy({});
         } catch (e) {
           err = e;
         }
@@ -1636,7 +1670,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2UpdatePolicy();
+          await iamPolicyManagementService.replaceV2Policy();
         } catch (e) {
           err = e;
         }
@@ -1646,61 +1680,61 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('v2GetPolicy', () => {
+  describe('getV2Policy', () => {
     describe('positive tests', () => {
-      function __v2GetPolicyTest() {
-        // Construct the params object for operation v2GetPolicy
-        const policyId = 'testString';
-        const v2GetPolicyParams = {
-          policyId,
+      function __getV2PolicyTest() {
+        // Construct the params object for operation getV2Policy
+        const id = 'testString';
+        const getV2PolicyParams = {
+          id,
         };
 
-        const v2GetPolicyResult = iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+        const getV2PolicyResult = iamPolicyManagementService.getV2Policy(getV2PolicyParams);
 
         // all methods should return a Promise
-        expectToBePromise(v2GetPolicyResult);
+        expectToBePromise(getV2PolicyResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+        expect(mockRequestOptions.path.id).toEqual(id);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __v2GetPolicyTest();
+        __getV2PolicyTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __v2GetPolicyTest();
+        __getV2PolicyTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __v2GetPolicyTest();
+        __getV2PolicyTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const policyId = 'testString';
+        const id = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const v2GetPolicyParams = {
-          policyId,
+        const getV2PolicyParams = {
+          id,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.v2GetPolicy(v2GetPolicyParams);
+        iamPolicyManagementService.getV2Policy(getV2PolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1709,7 +1743,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2GetPolicy({});
+          await iamPolicyManagementService.getV2Policy({});
         } catch (e) {
           err = e;
         }
@@ -1720,7 +1754,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2GetPolicy();
+          await iamPolicyManagementService.getV2Policy();
         } catch (e) {
           err = e;
         }
@@ -1730,61 +1764,61 @@ describe('IamPolicyManagementV1', () => {
     });
   });
 
-  describe('v2DeletePolicy', () => {
+  describe('deleteV2Policy', () => {
     describe('positive tests', () => {
-      function __v2DeletePolicyTest() {
-        // Construct the params object for operation v2DeletePolicy
-        const policyId = 'testString';
-        const v2DeletePolicyParams = {
-          policyId,
+      function __deleteV2PolicyTest() {
+        // Construct the params object for operation deleteV2Policy
+        const id = 'testString';
+        const deleteV2PolicyParams = {
+          id,
         };
 
-        const v2DeletePolicyResult = iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+        const deleteV2PolicyResult = iamPolicyManagementService.deleteV2Policy(deleteV2PolicyParams);
 
         // all methods should return a Promise
-        expectToBePromise(v2DeletePolicyResult);
+        expectToBePromise(deleteV2PolicyResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
         const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{policy_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v2/policies/{id}', 'DELETE');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.path.policy_id).toEqual(policyId);
+        expect(mockRequestOptions.path.id).toEqual(id);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __v2DeletePolicyTest();
+        __deleteV2PolicyTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.enableRetries();
-        __v2DeletePolicyTest();
+        __deleteV2PolicyTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         iamPolicyManagementService.disableRetries();
-        __v2DeletePolicyTest();
+        __deleteV2PolicyTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
-        const policyId = 'testString';
+        const id = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const v2DeletePolicyParams = {
-          policyId,
+        const deleteV2PolicyParams = {
+          id,
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyParams);
+        iamPolicyManagementService.deleteV2Policy(deleteV2PolicyParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -1793,7 +1827,7 @@ describe('IamPolicyManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2DeletePolicy({});
+          await iamPolicyManagementService.deleteV2Policy({});
         } catch (e) {
           err = e;
         }
@@ -1804,7 +1838,7 @@ describe('IamPolicyManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await iamPolicyManagementService.v2DeletePolicy();
+          await iamPolicyManagementService.deleteV2Policy();
         } catch (e) {
           err = e;
         }


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
PR's are currently open for staging and production docs. They are:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139 - merged
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140 - not merge

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No


## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md