### PR TITLE
fix(IAM Policy Management): update incorrect example operation id comments to match API definition

### DIFF
--- a/examples/iam-policy-management.v1.test.js
+++ b/examples/iam-policy-management.v1.test.js
@@ -185,7 +185,7 @@ describe('IamPolicyManagementV1', () => {
     });
 
     originalLog('replacePolicy() result:');
-    // begin-update_policy
+    // begin-replace_policy
 
     const policySubjects = [
       {
@@ -240,7 +240,7 @@ describe('IamPolicyManagementV1', () => {
       console.warn(err)
     }
 
-    // end-update_policy
+    // end-replace_policy
   });
   test('updatePolicyState request example', async () => {
     expect(examplePolicyId).toBeDefined();
@@ -256,7 +256,7 @@ describe('IamPolicyManagementV1', () => {
     });
 
     originalLog('updatePolicyState() result:');
-    // begin-patch_policy
+    // begin-update_policy_state
 
     const params = {
       policyId: examplePolicyId,
@@ -271,7 +271,7 @@ describe('IamPolicyManagementV1', () => {
       console.warn(err)
     }
 
-    // end-patch_policy
+    // end-update_policy_state
   });
   test('listPolicies request example', async () => {
     expect(exampleAccountId).not.toBeNull();
@@ -540,7 +540,7 @@ describe('IamPolicyManagementV1', () => {
     });
 
     originalLog('listV2Policies() result:');
-    // begin-list_v2_policy
+    // begin-list_v2_policies
 
     const params = {
       accountId: exampleAccountId,
@@ -555,7 +555,7 @@ describe('IamPolicyManagementV1', () => {
       console.warn(err);
     }
 
-    // end-list_v2_policy
+    // end-list_v2_policies
   });
   test('deleteV2Policy request example', async () => {
 
@@ -658,7 +658,7 @@ describe('IamPolicyManagementV1', () => {
     });
 
     originalLog('replaceRole() result:');
-    // begin-update_role
+    // begin-replace_role
 
     const updatedRoleActions = ['iam-groups.groups.read', 'iam-groups.groups.list'];
     const params = {
@@ -675,7 +675,7 @@ describe('IamPolicyManagementV1', () => {
       console.warn(err);
     }
 
-    // end-update_role
+    // end-replace_role
   });
   test('listRoles request example', async () => {
 


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Fixed commented operation id so example generator script will correctly. See operation ids: https://github.ibm.com/cloud-api-docs/iam-access-management/blob/test/iam-policy-management.yaml#L447

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features) - N/A
- [x] Docs have been added / updated (for bug fixes / features) - Helps to update docs for accuracy!

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->
No change in behavior, simply will allow generation of sdk examples in api docs.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->