### PR TITLE
fix: report usage in usage-metering api

### DIFF
--- a/test/unit/usage-metering.v4.test.js
+++ b/test/unit/usage-metering.v4.test.js
@@ -138,7 +138,7 @@ describe('UsageMeteringV4', () => {
 
         const options = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v4/metering/resources/{resource_id}/usage', 'POST');
+        checkUrlAndMethod(options, `/v4/metering/resources/${params.resourceId}/usage`, 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);

--- a/usage-metering/v4.ts
+++ b/usage-metering/v4.ts
@@ -133,7 +133,7 @@ class UsageMeteringV4 extends BaseService {
 
     const parameters = {
       options: {
-        url: '/v4/metering/resources/{resource_id}/usage',
+        url: `/v4/metering/resources/${_params.resourceId}/usage`,
         method: 'POST',
         body,
         path,


### PR DESCRIPTION
## PR summary
Fix url field in the options object in the reportResourceUsage method of UsageMeteringV4 to use resourceId provided as argument

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Currently, calling reportResourceUsage returns an authorisation error despite providing correct argument values.
New, use resource id provided as argument to generate the url used to report resource usage.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No