### PR TITLE
feat(IAM Identity): add trusted profile identities api

### DIFF
--- a/examples/iam-identity.v1.test.js
+++ b/examples/iam-identity.v1.test.js
@@ -77,6 +77,7 @@ describe('IamIdentityV1', () => {
 
   let profileId = null;
   let profileEtag = null;
+  let profileIdentitiesEtag = null;
 
   let claimRuleId = null;
   let claimRuleEtag = null;
@@ -825,7 +826,7 @@ describe('IamIdentityV1', () => {
     // begin-create_link
 
     const CreateProfileLinkRequestLink = {
-      crn: 'crn:v1:staging:public:iam-identity::a/18e3020749ce4744b0b472466d61fdb4::computeresource:Fake-Compute-Resource',
+      crn: `crn:v1:staging:public:iam-identity::a/${accountId}::computeresource:Fake-Compute-Resource`,
       namespace: 'default',
       name: 'nice name',
     };
@@ -930,6 +931,166 @@ describe('IamIdentityV1', () => {
     }
 
     // end-delete_link
+  });
+  test('getProfileIdentities request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getProfileIdentities() result:');
+    // begin-get_profile_identities
+
+    const params = {
+      profileId,
+    };
+
+    try {
+      const res = await iamIdentityService.getProfileIdentities(params);
+      const { result } = res;
+      profileIdentitiesEtag = result.entity_tag;
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_profile_identities
+   
+  });
+  test('setProfileIdentities request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('setProfileIdentities() result:');
+    // begin-set_profile_identities
+    const profileaccounts=[accountId];
+    const ProfileIdentity= {
+      identifier: iamId,
+      type: 'user',
+      accounts: profileaccounts,
+      description: 'identity description'
+    }
+    const profileIdentities= [ProfileIdentity]
+    const params = {
+      profileId: profileId,
+      identities: profileIdentities,
+      ifMatch: profileIdentitiesEtag
+    };
+
+    try {
+      const res = await iamIdentityService.setProfileIdentities(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-set_profile_identities
+  });
+  test('getProfileIdentity request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getProfileIdentity() result:');
+    // begin-get_profile_identity
+
+    const params = {
+      profileId: profileId,
+      identityType: 'user',
+      identifierId: iamId
+    };
+
+    try {
+      const res = await iamIdentityService.getProfileIdentity(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_profile_identity
+   
+  });
+  test('setProfileIdentity request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('setProfileIdentity() result:');
+    // begin-set_profile_identity
+
+    const profileaccounts=[accountId];
+    const params = {
+      profileId: profileId,
+      identityType: 'user',
+      identifier: iamIdMember,
+      type: 'user',
+      accounts: profileaccounts,
+      description: 'identity description'
+    };
+
+    try {
+      const res = await iamIdentityService.setProfileIdentity(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-set_profile_identity
+   
+  });
+  test('deleteProfileIdentity request example', async () => {
+
+    consoleLogMock.mockImplementation(output => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation(output => {
+      originalWarn(output);
+      // when the test fails we need to print out the error message and stop execution right after it
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('deleteProfileIdentity() result:');
+    // begin-delete_profile_identity
+
+    const params = {
+      profileId: profileId,
+      identityType: 'user',
+      identifierId: iamIdMember
+    };
+
+    try {
+      const res = await iamIdentityService.deleteProfileIdentity(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-delete_profile_identity
+   
   });
   test('deleteProfile request example', async () => {
 

--- a/iam-identity/v1.ts
+++ b/iam-identity/v1.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.64.0-959a5845-20230112-195144
+ * IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
  */
 
 import * as extend from 'extend';
@@ -1781,6 +1781,310 @@ class IamIdentityV1 extends BaseService {
 
     return this.createRequest(parameters);
   }
+
+  /**
+   * Get a list of identities that can assume the trusted profile.
+   *
+   * Get a list of identities that can assume the trusted profile.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.profileId - ID of the trusted profile.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentitiesResponse>>}
+   */
+  public getProfileIdentities(
+    params: IamIdentityV1.GetProfileIdentitiesParams
+  ): Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentitiesResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['profileId'];
+    const _validParams = ['profileId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'profile-id': _params.profileId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamIdentityV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getProfileIdentities'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/profiles/{profile-id}/identities',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update the list of identities that can assume the trusted profile.
+   *
+   * Update the list of identities that can assume the trusted profile.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.profileId - ID of the trusted profile.
+   * @param {string} params.ifMatch - Entity tag of the Identities to be updated. Specify the tag that you retrieved
+   * when reading the Profile Identities. This value helps identify parallel usage of this API. Pass * to indicate
+   * updating any available version, which may result in stale updates.
+   * @param {ProfileIdentity[]} [params.identities] - List of identities that can assume the trusted profile.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentitiesResponse>>}
+   */
+  public setProfileIdentities(
+    params: IamIdentityV1.SetProfileIdentitiesParams
+  ): Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentitiesResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['profileId', 'ifMatch'];
+    const _validParams = ['profileId', 'ifMatch', 'identities', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'identities': _params.identities,
+    };
+
+    const path = {
+      'profile-id': _params.profileId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamIdentityV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'setProfileIdentities'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/profiles/{profile-id}/identities',
+        method: 'PUT',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'If-Match': _params.ifMatch,
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Add a specific identity that can assume the trusted profile.
+   *
+   * Add a specific identity that can assume the trusted profile.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.profileId - ID of the trusted profile.
+   * @param {string} params.identityType - Type of the identity.
+   * @param {string} params.identifier - Identifier of the identity that can assume the trusted profiles. This can be a
+   * user identifier (IAM id), serviceid or crn. Internally it uses account id of the service id for the identifier
+   * 'serviceid' and for the identifier 'crn' it uses account id contained in the CRN.
+   * @param {string} params.type - Type of the identity.
+   * @param {string} [params.iamId] - IAM ID of the identity.
+   * @param {string[]} [params.accounts] - Only valid for the type user. Accounts from which a user can assume the
+   * trusted profile.
+   * @param {string} [params.description] - Description of the identity that can assume the trusted profile. This is
+   * optional field for all the types of identities. When this field is not set for the identity type 'serviceid' then
+   * the description of the service id is used. Description is recommended for the identity type 'crn' E.g. 'Instance
+   * 1234 of IBM Cloud Service project'.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentity>>}
+   */
+  public setProfileIdentity(
+    params: IamIdentityV1.SetProfileIdentityParams
+  ): Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentity>> {
+    const _params = { ...params };
+    const _requiredParams = ['profileId', 'identityType', 'identifier', 'type'];
+    const _validParams = [
+      'profileId',
+      'identityType',
+      'identifier',
+      'type',
+      'iamId',
+      'accounts',
+      'description',
+      'headers',
+    ];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'identifier': _params.identifier,
+      'type': _params.type,
+      'iam_id': _params.iamId,
+      'accounts': _params.accounts,
+      'description': _params.description,
+    };
+
+    const path = {
+      'profile-id': _params.profileId,
+      'identity-type': _params.identityType,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamIdentityV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'setProfileIdentity'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/profiles/{profile-id}/identities/{identity-type}',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get the identity that can assume the trusted profile.
+   *
+   * Get the identity that can assume the trusted profile.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.profileId - ID of the trusted profile.
+   * @param {string} params.identityType - Type of the identity.
+   * @param {string} params.identifierId - Identifier of the identity that can assume the trusted profiles.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentity>>}
+   */
+  public getProfileIdentity(
+    params: IamIdentityV1.GetProfileIdentityParams
+  ): Promise<IamIdentityV1.Response<IamIdentityV1.ProfileIdentity>> {
+    const _params = { ...params };
+    const _requiredParams = ['profileId', 'identityType', 'identifierId'];
+    const _validParams = ['profileId', 'identityType', 'identifierId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'profile-id': _params.profileId,
+      'identity-type': _params.identityType,
+      'identifier-id': _params.identifierId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamIdentityV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getProfileIdentity'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/profiles/{profile-id}/identities/{identity-type}/{identifier-id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete the identity that can assume the trusted profile.
+   *
+   * Delete the identity that can assume the trusted profile.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.profileId - ID of the trusted profile.
+   * @param {string} params.identityType - Type of the identity.
+   * @param {string} params.identifierId - Identifier of the identity that can assume the trusted profiles.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<IamIdentityV1.Response<IamIdentityV1.EmptyObject>>}
+   */
+  public deleteProfileIdentity(
+    params: IamIdentityV1.DeleteProfileIdentityParams
+  ): Promise<IamIdentityV1.Response<IamIdentityV1.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['profileId', 'identityType', 'identifierId'];
+    const _validParams = ['profileId', 'identityType', 'identifierId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'profile-id': _params.profileId,
+      'identity-type': _params.identityType,
+      'identifier-id': _params.identifierId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      IamIdentityV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteProfileIdentity'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/profiles/{profile-id}/identities/{identity-type}/{identifier-id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(true, sdkHeaders, {}, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
   /*************************
    * accountSettings
    ************************/
@@ -1868,6 +2172,7 @@ class IamIdentityV1 extends BaseService {
    * created for the account.
    * @param {string} [params.mfa] - Defines the MFA trait for the account. Valid values:
    *   * NONE - No MFA trait set
+   *   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
    *   * TOTP - For all non-federated IBMId users
    *   * TOTP4ALL - For all users
    *   * LEVEL1 - Email-based MFA for all users
@@ -2731,6 +3036,111 @@ namespace IamIdentityV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `getProfileIdentities` operation. */
+  export interface GetProfileIdentitiesParams {
+    /** ID of the trusted profile. */
+    profileId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `setProfileIdentities` operation. */
+  export interface SetProfileIdentitiesParams {
+    /** ID of the trusted profile. */
+    profileId: string;
+    /** Entity tag of the Identities to be updated. Specify the tag that you retrieved when reading the Profile
+     *  Identities. This value helps identify parallel usage of this API. Pass * to indicate updating any available
+     *  version, which may result in stale updates.
+     */
+    ifMatch: string;
+    /** List of identities that can assume the trusted profile. */
+    identities?: ProfileIdentity[];
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `setProfileIdentity` operation. */
+  export interface SetProfileIdentityParams {
+    /** ID of the trusted profile. */
+    profileId: string;
+    /** Type of the identity. */
+    identityType: SetProfileIdentityConstants.IdentityType | string;
+    /** Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id),
+     *  serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the
+     *  identifier 'crn' it uses account id contained in the CRN.
+     */
+    identifier: string;
+    /** Type of the identity. */
+    type: SetProfileIdentityConstants.Type | string;
+    /** IAM ID of the identity. */
+    iamId?: string;
+    /** Only valid for the type user. Accounts from which a user can assume the trusted profile. */
+    accounts?: string[];
+    /** Description of the identity that can assume the trusted profile. This is optional field for all the types of
+     *  identities. When this field is not set for the identity type 'serviceid' then the description of the service id
+     *  is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service
+     *  project'.
+     */
+    description?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `setProfileIdentity` operation. */
+  export namespace SetProfileIdentityConstants {
+    /** Type of the identity. */
+    export enum IdentityType {
+      USER = 'user',
+      SERVICEID = 'serviceid',
+      CRN = 'crn',
+    }
+    /** Type of the identity. */
+    export enum Type {
+      USER = 'user',
+      SERVICEID = 'serviceid',
+      CRN = 'crn',
+    }
+  }
+
+  /** Parameters for the `getProfileIdentity` operation. */
+  export interface GetProfileIdentityParams {
+    /** ID of the trusted profile. */
+    profileId: string;
+    /** Type of the identity. */
+    identityType: GetProfileIdentityConstants.IdentityType | string;
+    /** Identifier of the identity that can assume the trusted profiles. */
+    identifierId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `getProfileIdentity` operation. */
+  export namespace GetProfileIdentityConstants {
+    /** Type of the identity. */
+    export enum IdentityType {
+      USER = 'user',
+      SERVICEID = 'serviceid',
+      CRN = 'crn',
+    }
+  }
+
+  /** Parameters for the `deleteProfileIdentity` operation. */
+  export interface DeleteProfileIdentityParams {
+    /** ID of the trusted profile. */
+    profileId: string;
+    /** Type of the identity. */
+    identityType: DeleteProfileIdentityConstants.IdentityType | string;
+    /** Identifier of the identity that can assume the trusted profiles. */
+    identifierId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `deleteProfileIdentity` operation. */
+  export namespace DeleteProfileIdentityConstants {
+    /** Type of the identity. */
+    export enum IdentityType {
+      USER = 'user',
+      SERVICEID = 'serviceid',
+      CRN = 'crn',
+    }
+  }
+
   /** Parameters for the `getAccountSettings` operation. */
   export interface GetAccountSettingsParams {
     /** Unique ID of the account. */
@@ -2767,6 +3177,7 @@ namespace IamIdentityV1 {
     allowedIpAddresses?: string;
     /** Defines the MFA trait for the account. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -2819,9 +3230,10 @@ namespace IamIdentityV1 {
       NOT_RESTRICTED = 'NOT_RESTRICTED',
       NOT_SET = 'NOT_SET',
     }
-    /** Defines the MFA trait for the account. Valid values: * NONE - No MFA trait set * TOTP - For all non-federated IBMId users * TOTP4ALL - For all users * LEVEL1 - Email-based MFA for all users * LEVEL2 - TOTP-based MFA for all users * LEVEL3 - U2F MFA for all users. */
+    /** Defines the MFA trait for the account. Valid values: * NONE - No MFA trait set * NONE_NO_ROPC- No MFA, disable CLI logins with only a password * TOTP - For all non-federated IBMId users * TOTP4ALL - For all users * LEVEL1 - Email-based MFA for all users * LEVEL2 - TOTP-based MFA for all users * LEVEL3 - U2F MFA for all users. */
     export enum Mfa {
       NONE = 'NONE',
+      NONE_NO_ROPC = 'NONE_NO_ROPC',
       TOTP = 'TOTP',
       TOTP4ALL = 'TOTP4ALL',
       LEVEL1 = 'LEVEL1',
@@ -2922,6 +3334,7 @@ namespace IamIdentityV1 {
     entity_tag: string;
     /** Defines the MFA trait for the account. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -2967,6 +3380,7 @@ namespace IamIdentityV1 {
     iam_id: string;
     /** Defines the MFA requirement for the user. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -3150,6 +3564,7 @@ namespace IamIdentityV1 {
   export interface IdBasedMfaEnrollment {
     /** Defines the MFA trait for the account. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -3159,6 +3574,7 @@ namespace IamIdentityV1 {
     trait_account_default: string;
     /** Defines the MFA trait for the account. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -3168,6 +3584,7 @@ namespace IamIdentityV1 {
     trait_user_specific?: string;
     /** Defines the MFA trait for the account. Valid values:
      *    * NONE - No MFA trait set
+     *    * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
      *    * TOTP - For all non-federated IBMId users
      *    * TOTP4ALL - For all users
      *    * LEVEL1 - Email-based MFA for all users
@@ -3241,11 +3658,40 @@ namespace IamIdentityV1 {
     rules: ProfileClaimRule[];
   }
 
+  /** ProfileIdentitiesResponse. */
+  export interface ProfileIdentitiesResponse {
+    /** Entity tag of the profile identities response. */
+    entity_tag?: string;
+    /** List of identities. */
+    identities?: ProfileIdentity[];
+  }
+
+  /** ProfileIdentity. */
+  export interface ProfileIdentity {
+    /** IAM ID of the identity. */
+    iam_id?: string;
+    /** Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id),
+     *  serviceid or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the
+     *  identifier 'crn' it uses account id contained in the CRN.
+     */
+    identifier: string;
+    /** Type of the identity. */
+    type: string;
+    /** Only valid for the type user. Accounts from which a user can assume the trusted profile. */
+    accounts?: string[];
+    /** Description of the identity that can assume the trusted profile. This is optional field for all the types of
+     *  identities. When this field is not set for the identity type 'serviceid' then the description of the service id
+     *  is used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service
+     *  project'.
+     */
+    description?: string;
+  }
+
   /** Link details. */
   export interface ProfileLink {
-    /** the unique identifier of the claim rule. */
+    /** the unique identifier of the link. */
     id: string;
-    /** version of the claim rule. */
+    /** version of the link. */
     entity_tag: string;
     /** If set contains a date time string of the creation date in ISO format. */
     created_at: string;

--- a/test/integration/iam-identity.v1.test.js
+++ b/test/integration/iam-identity.v1.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 /* eslint-disable no-console */
 /**
  * (C) Copyright IBM Corp. 2020, 2021.
@@ -53,6 +54,7 @@ let profileId1;
 let profileId2;
 let profileIamId;
 let profileEtag;
+let profileIdentitiesEtag;
 
 let claimRuleId1;
 let claimRuleId2;
@@ -1070,6 +1072,100 @@ describe('IamIdentityV1_integration', () => {
       });
   });
 
+  test('getProfileIdentities()', async () => {
+    const profileIdentities = [];
+    const params = {
+      profileId: profileId2,
+    };
+
+    const res = await iamIdentityService.getProfileIdentities(params);
+    expect(res.status).toEqual(200);
+
+    const { result } = res;
+    expect(result.identities).toBeDefined();
+    profileIdentitiesEtag = result.entity_tag;
+    for (const elem of result.identities) {
+      if (elem.identifier === iamId) {
+        profileIdentities.push(elem);
+      }
+    }
+    expect(profileIdentities).toHaveLength(0);
+  });
+
+  test('setProfileIdentities()', async () => {
+    const identifiers = [];
+    const profileaccounts=[accountId];
+    const ProfileIdentity= {
+      identifier: iamId,
+      type: 'user',
+      accounts: profileaccounts,
+      description: 'identity description'
+    }
+    const profileIdentities= [ProfileIdentity]
+    const params = {
+      profileId: profileId2,
+      identities: profileIdentities,
+      ifMatch: profileIdentitiesEtag
+    };
+
+    const res = await iamIdentityService.setProfileIdentities(params);
+    expect(res.status).toEqual(200);
+
+    const { result } = res;
+    expect(result.identities).toBeDefined();
+    profileIdentitiesEtag = result.entity_tag;
+    for (const elem of result.identities) {
+      if (elem.identifier === iamId) {
+        identifiers.push(elem);
+      }
+    }
+    expect(identifiers).toHaveLength(1);
+  });
+
+  test('getProfileIdentity()', async () => {
+    const params = {
+      profileId: profileId2,
+      identityType: 'user',
+      identifierId: iamId
+    };
+
+    const res = await iamIdentityService.getProfileIdentity(params);
+    expect(res.status).toEqual(200);
+
+    const { result } = res;
+    expect(result.identifier).toBeDefined();
+  });
+
+  test('setProfileIdentity()', async () => {
+    const profileaccounts=[accountId];
+    const params = {
+      profileId: profileId2,
+      identityType: 'user',
+      identifier: iamIdMember,
+      type: 'user',
+      accounts: profileaccounts,
+      description: 'identity description'
+    };
+
+    const res = await iamIdentityService.setProfileIdentity(params);
+    expect(res.status).toEqual(200);
+
+    const { result } = res;
+    expect(result.identifier).toBeDefined();
+  });
+
+  test('deleteProfileIdentity()', async () => {
+    const params = {
+      profileId: profileId2,
+      identityType: 'user',
+      identifierId: iamIdMember
+    };
+
+    const res = await iamIdentityService.deleteProfileIdentity(params);
+    expect(res.status).toEqual(204);
+
+  });
+
   test('deleteProfile2()', (done) => {
     expect(profileId2).toBeDefined();
     expect(profileId2).not.toBeNull();
@@ -1465,7 +1561,7 @@ describe('IamIdentityV1_integration', () => {
       accountId,
       iamId,
     };
-    const response = await iamIdentityService.getMfaReport(params);
+    const response = await iamIdentityService.getMfaStatus(params);
     expect(response).not.toBeNull();
     expect(response.iam_id).not.toBeNull();
   });

--- a/test/unit/iam-identity.v1.test.js
+++ b/test/unit/iam-identity.v1.test.js
@@ -15,9 +15,9 @@
  */
 
 // need to import the whole package to mock getAuthenticatorFromEnvironment
-const core = require('ibm-cloud-sdk-core');
+const sdkCorePackage = require('ibm-cloud-sdk-core');
 
-const { NoAuthAuthenticator, unitTestUtils } = core;
+const { NoAuthAuthenticator, unitTestUtils } = sdkCorePackage;
 
 const IamIdentityV1 = require('../../dist/iam-identity/v1');
 
@@ -32,7 +32,7 @@ const {
 
 const iamIdentityServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
-  url: 'https://iam.cloud.ibm.com',
+  url: 'https://iam.test.cloud.ibm.com',
 };
 
 const iamIdentityService = new IamIdentityV1(iamIdentityServiceOptions);
@@ -46,7 +46,7 @@ function mock_createRequest() {
 }
 
 // dont actually construct an authenticator
-const getAuthenticatorMock = jest.spyOn(core, 'getAuthenticatorFromEnvironment');
+const getAuthenticatorMock = jest.spyOn(sdkCorePackage, 'getAuthenticatorFromEnvironment');
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
 
 describe('IamIdentityV1', () => {
@@ -2799,6 +2799,489 @@ describe('IamIdentityV1', () => {
         let err;
         try {
           await iamIdentityService.deleteLink();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getProfileIdentities', () => {
+    describe('positive tests', () => {
+      function __getProfileIdentitiesTest() {
+        // Construct the params object for operation getProfileIdentities
+        const profileId = 'testString';
+        const getProfileIdentitiesParams = {
+          profileId,
+        };
+
+        const getProfileIdentitiesResult = iamIdentityService.getProfileIdentities(getProfileIdentitiesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getProfileIdentitiesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/profiles/{profile-id}/identities', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path['profile-id']).toEqual(profileId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getProfileIdentitiesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.enableRetries();
+        __getProfileIdentitiesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.disableRetries();
+        __getProfileIdentitiesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profileId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getProfileIdentitiesParams = {
+          profileId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamIdentityService.getProfileIdentities(getProfileIdentitiesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamIdentityService.getProfileIdentities({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamIdentityService.getProfileIdentities();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('setProfileIdentities', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // ProfileIdentity
+      const profileIdentityModel = {
+        iam_id: 'testString',
+        identifier: 'testString',
+        type: 'user',
+        accounts: ['testString'],
+        description: 'testString',
+      };
+
+      function __setProfileIdentitiesTest() {
+        // Construct the params object for operation setProfileIdentities
+        const profileId = 'testString';
+        const ifMatch = 'testString';
+        const identities = [profileIdentityModel];
+        const setProfileIdentitiesParams = {
+          profileId,
+          ifMatch,
+          identities,
+        };
+
+        const setProfileIdentitiesResult = iamIdentityService.setProfileIdentities(setProfileIdentitiesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(setProfileIdentitiesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/profiles/{profile-id}/identities', 'PUT');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        checkUserHeader(createRequestMock, 'If-Match', ifMatch);
+        expect(mockRequestOptions.body.identities).toEqual(identities);
+        expect(mockRequestOptions.path['profile-id']).toEqual(profileId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __setProfileIdentitiesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.enableRetries();
+        __setProfileIdentitiesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.disableRetries();
+        __setProfileIdentitiesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profileId = 'testString';
+        const ifMatch = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const setProfileIdentitiesParams = {
+          profileId,
+          ifMatch,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamIdentityService.setProfileIdentities(setProfileIdentitiesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamIdentityService.setProfileIdentities({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamIdentityService.setProfileIdentities();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('setProfileIdentity', () => {
+    describe('positive tests', () => {
+      function __setProfileIdentityTest() {
+        // Construct the params object for operation setProfileIdentity
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifier = 'testString';
+        const type = 'user';
+        const iamId = 'testString';
+        const accounts = ['testString'];
+        const description = 'testString';
+        const setProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifier,
+          type,
+          iamId,
+          accounts,
+          description,
+        };
+
+        const setProfileIdentityResult = iamIdentityService.setProfileIdentity(setProfileIdentityParams);
+
+        // all methods should return a Promise
+        expectToBePromise(setProfileIdentityResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/profiles/{profile-id}/identities/{identity-type}', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.identifier).toEqual(identifier);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.iam_id).toEqual(iamId);
+        expect(mockRequestOptions.body.accounts).toEqual(accounts);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.path['profile-id']).toEqual(profileId);
+        expect(mockRequestOptions.path['identity-type']).toEqual(identityType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __setProfileIdentityTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.enableRetries();
+        __setProfileIdentityTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.disableRetries();
+        __setProfileIdentityTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifier = 'testString';
+        const type = 'user';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const setProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifier,
+          type,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamIdentityService.setProfileIdentity(setProfileIdentityParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamIdentityService.setProfileIdentity({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamIdentityService.setProfileIdentity();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getProfileIdentity', () => {
+    describe('positive tests', () => {
+      function __getProfileIdentityTest() {
+        // Construct the params object for operation getProfileIdentity
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifierId = 'testString';
+        const getProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifierId,
+        };
+
+        const getProfileIdentityResult = iamIdentityService.getProfileIdentity(getProfileIdentityParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getProfileIdentityResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/profiles/{profile-id}/identities/{identity-type}/{identifier-id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path['profile-id']).toEqual(profileId);
+        expect(mockRequestOptions.path['identity-type']).toEqual(identityType);
+        expect(mockRequestOptions.path['identifier-id']).toEqual(identifierId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getProfileIdentityTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.enableRetries();
+        __getProfileIdentityTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.disableRetries();
+        __getProfileIdentityTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifierId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifierId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamIdentityService.getProfileIdentity(getProfileIdentityParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamIdentityService.getProfileIdentity({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamIdentityService.getProfileIdentity();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteProfileIdentity', () => {
+    describe('positive tests', () => {
+      function __deleteProfileIdentityTest() {
+        // Construct the params object for operation deleteProfileIdentity
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifierId = 'testString';
+        const deleteProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifierId,
+        };
+
+        const deleteProfileIdentityResult = iamIdentityService.deleteProfileIdentity(deleteProfileIdentityParams);
+
+        // all methods should return a Promise
+        expectToBePromise(deleteProfileIdentityResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v1/profiles/{profile-id}/identities/{identity-type}/{identifier-id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path['profile-id']).toEqual(profileId);
+        expect(mockRequestOptions.path['identity-type']).toEqual(identityType);
+        expect(mockRequestOptions.path['identifier-id']).toEqual(identifierId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteProfileIdentityTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.enableRetries();
+        __deleteProfileIdentityTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        iamIdentityService.disableRetries();
+        __deleteProfileIdentityTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const profileId = 'testString';
+        const identityType = 'user';
+        const identifierId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteProfileIdentityParams = {
+          profileId,
+          identityType,
+          identifierId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        iamIdentityService.deleteProfileIdentity(deleteProfileIdentityParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await iamIdentityService.deleteProfileIdentity({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await iamIdentityService.deleteProfileIdentity();
         } catch (e) {
           err = e;
         }


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Added feature support for Trusted Profile identities work, add, get, delete identities associated with the profile. 


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

SDK adopters will be able to call Trusted profile identities APIs.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->

API defintion:
[Staging](https://test.cloud.ibm.com/apidocs/iam-identity-token-api?code=java#get-profile-identities)


Test information:

Integration Tests:
```sh
Test Suites: 1 passed, 1 total
Tests:       61 passed, 61 total
Snapshots:   0 total
Time:        51.739 s, estimated 53 s
```
