### PR TITLE
fix(Usage Reports): re-gen service after recent API changes

### DIFF
--- a/test/unit/usage-reports.v4.test.js
+++ b/test/unit/usage-reports.v4.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
+/* eslint-disable no-await-in-loop */
+
+const nock = require('nock');
+
 // need to import the whole package to mock getAuthenticatorFromEnvironment
 const sdkCorePackage = require('ibm-cloud-sdk-core');
 
 const { NoAuthAuthenticator, unitTestUtils } = sdkCorePackage;
-
 const UsageReportsV4 = require('../../dist/usage-reports/v4');
-const nock = require('nock');
-
-/* eslint-disable no-await-in-loop */
 
 const {
   getOptions,
@@ -58,7 +58,6 @@ const getAuthenticatorMock = jest.spyOn(sdkCorePackage, 'getAuthenticatorFromEnv
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
 
 describe('UsageReportsV4', () => {
-
   beforeEach(() => {
     mock_createRequest();
   });
@@ -69,7 +68,7 @@ describe('UsageReportsV4', () => {
     }
     getAuthenticatorMock.mockClear();
   });
-  
+
   describe('the newInstance method', () => {
     test('should use defaults when options not provided', () => {
       const testInstance = UsageReportsV4.newInstance();
@@ -412,8 +411,9 @@ describe('UsageReportsV4', () => {
         const accountId = 'testString';
         const billingmonth = 'testString';
         const names = true;
+        const tags = true;
         const acceptLanguage = 'testString';
-        const limit = 1;
+        const limit = 30;
         const start = 'testString';
         const resourceGroupId = 'testString';
         const organizationId = 'testString';
@@ -425,6 +425,7 @@ describe('UsageReportsV4', () => {
           accountId,
           billingmonth,
           names,
+          tags,
           acceptLanguage,
           limit,
           start,
@@ -452,6 +453,7 @@ describe('UsageReportsV4', () => {
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
         expect(mockRequestOptions.qs._names).toEqual(names);
+        expect(mockRequestOptions.qs._tags).toEqual(tags);
         expect(mockRequestOptions.qs._limit).toEqual(limit);
         expect(mockRequestOptions.qs._start).toEqual(start);
         expect(mockRequestOptions.qs.resource_group_id).toEqual(resourceGroupId);
@@ -527,16 +529,16 @@ describe('UsageReportsV4', () => {
       const serviceUrl = usageReportsServiceOptions.url;
       const path = '/v4/accounts/testString/resource_instances/usage/testString';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
 
       beforeEach(() => {
         unmock_createRequest();
         const scope = nock(serviceUrl)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse2);
       });
 
@@ -550,8 +552,9 @@ describe('UsageReportsV4', () => {
           accountId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceGroupId: 'testString',
           organizationId: 'testString',
           resourceInstanceId: 'testString',
@@ -575,8 +578,9 @@ describe('UsageReportsV4', () => {
           accountId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceGroupId: 'testString',
           organizationId: 'testString',
           resourceInstanceId: 'testString',
@@ -600,8 +604,9 @@ describe('UsageReportsV4', () => {
         const resourceGroupId = 'testString';
         const billingmonth = 'testString';
         const names = true;
+        const tags = true;
         const acceptLanguage = 'testString';
-        const limit = 1;
+        const limit = 30;
         const start = 'testString';
         const resourceInstanceId = 'testString';
         const resourceId = 'testString';
@@ -612,6 +617,7 @@ describe('UsageReportsV4', () => {
           resourceGroupId,
           billingmonth,
           names,
+          tags,
           acceptLanguage,
           limit,
           start,
@@ -637,6 +643,7 @@ describe('UsageReportsV4', () => {
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
         expect(mockRequestOptions.qs._names).toEqual(names);
+        expect(mockRequestOptions.qs._tags).toEqual(tags);
         expect(mockRequestOptions.qs._limit).toEqual(limit);
         expect(mockRequestOptions.qs._start).toEqual(start);
         expect(mockRequestOptions.qs.resource_instance_id).toEqual(resourceInstanceId);
@@ -713,16 +720,16 @@ describe('UsageReportsV4', () => {
       const serviceUrl = usageReportsServiceOptions.url;
       const path = '/v4/accounts/testString/resource_groups/testString/resource_instances/usage/testString';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
 
       beforeEach(() => {
         unmock_createRequest();
         const scope = nock(serviceUrl)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse2);
       });
 
@@ -737,8 +744,9 @@ describe('UsageReportsV4', () => {
           resourceGroupId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceInstanceId: 'testString',
           resourceId: 'testString',
           planId: 'testString',
@@ -761,8 +769,9 @@ describe('UsageReportsV4', () => {
           resourceGroupId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceInstanceId: 'testString',
           resourceId: 'testString',
           planId: 'testString',
@@ -784,8 +793,9 @@ describe('UsageReportsV4', () => {
         const organizationId = 'testString';
         const billingmonth = 'testString';
         const names = true;
+        const tags = true;
         const acceptLanguage = 'testString';
-        const limit = 1;
+        const limit = 30;
         const start = 'testString';
         const resourceInstanceId = 'testString';
         const resourceId = 'testString';
@@ -796,6 +806,7 @@ describe('UsageReportsV4', () => {
           organizationId,
           billingmonth,
           names,
+          tags,
           acceptLanguage,
           limit,
           start,
@@ -821,6 +832,7 @@ describe('UsageReportsV4', () => {
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'Accept-Language', acceptLanguage);
         expect(mockRequestOptions.qs._names).toEqual(names);
+        expect(mockRequestOptions.qs._tags).toEqual(tags);
         expect(mockRequestOptions.qs._limit).toEqual(limit);
         expect(mockRequestOptions.qs._start).toEqual(start);
         expect(mockRequestOptions.qs.resource_instance_id).toEqual(resourceInstanceId);
@@ -897,16 +909,16 @@ describe('UsageReportsV4', () => {
       const serviceUrl = usageReportsServiceOptions.url;
       const path = '/v4/accounts/testString/organizations/testString/resource_instances/usage/testString';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"next":{"href":"https://myhost.com/somePath?_start=1"},"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"plan_id":"plan_id","plan_name":"plan_name","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716}]}';
+        '{"total_count":2,"limit":1,"resources":[{"account_id":"account_id","resource_instance_id":"resource_instance_id","resource_instance_name":"resource_instance_name","resource_id":"resource_id","catalog_id":"catalog_id","resource_name":"resource_name","resource_group_id":"resource_group_id","resource_group_name":"resource_group_name","organization_id":"organization_id","organization_name":"organization_name","space_id":"space_id","space_name":"space_name","consumer_id":"consumer_id","region":"region","pricing_region":"pricing_region","pricing_country":"USA","currency_code":"USD","billable":true,"parent_resource_instance_id":"parent_resource_instance_id","plan_id":"plan_id","plan_name":"plan_name","pricing_plan_id":"pricing_plan_id","month":"2017-08","usage":[{"metric":"UP-TIME","metric_name":"UP-TIME","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130.0,"price":["anyValue"],"unit":"HOURS","unit_name":"HOURS","non_chargeable":true,"discounts":[{"ref":"Discount-d27beddb-111b-4bbf-8cb1-b770f531c1a9","name":"platform-discount","display_name":"Platform Service Discount","discount":5}]}],"pending":true,"currency_rate":10.8716,"tags":["anyValue"],"service_tags":["anyValue"]}]}';
 
       beforeEach(() => {
         unmock_createRequest();
         const scope = nock(serviceUrl)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse2);
       });
 
@@ -921,8 +933,9 @@ describe('UsageReportsV4', () => {
           organizationId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceInstanceId: 'testString',
           resourceId: 'testString',
           planId: 'testString',
@@ -945,8 +958,9 @@ describe('UsageReportsV4', () => {
           organizationId: 'testString',
           billingmonth: 'testString',
           names: true,
+          tags: true,
           acceptLanguage: 'testString',
-          limit: 1,
+          limit: 30,
           resourceInstanceId: 'testString',
           resourceId: 'testString',
           planId: 'testString',
@@ -1651,9 +1665,9 @@ describe('UsageReportsV4', () => {
       beforeEach(() => {
         unmock_createRequest();
         const scope = nock(serviceUrl)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse1)
-          .get(uri => uri.includes(path))
+          .get((uri) => uri.includes(path))
           .reply(200, mockPagerResponse2);
       });
 

--- a/usage-reports/v4.ts
+++ b/usage-reports/v4.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.75.0-726bc7e3-20230713-221716
+ * IBM OpenAPI SDK Code Generator Version: 3.87.0-91c7c775-20240320-213027
  */
 
 /* eslint-disable max-classes-per-file */
@@ -26,10 +26,10 @@ import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
 import {
   Authenticator,
   BaseService,
-  getAuthenticatorFromEnvironment,
-  validateParams,
   UserOptions,
+  getAuthenticatorFromEnvironment,
   getQueryParam,
+  validateParams,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
 
@@ -54,7 +54,7 @@ class UsageReportsV4 extends BaseService {
    * @param {UserOptions} [options] - The parameters to send to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service
-   * @param {string} [options.serviceUrl] - The URL for the service
+   * @param {string} [options.serviceUrl] - The base URL for the service
    * @returns {UsageReportsV4}
    */
 
@@ -79,7 +79,7 @@ class UsageReportsV4 extends BaseService {
    * Construct a UsageReportsV4 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base URL for the service
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {Authenticator} options.authenticator - The Authenticator object used to authenticate requests to the service
    * @constructor
@@ -308,6 +308,8 @@ class UsageReportsV4 extends BaseService {
    * yyyy-mm.
    * @param {boolean} [params.names] - Include the name of every resource, plan, resource instance, organization, and
    * resource group.
+   * @param {boolean} [params.tags] - Include the tags associated with every resource instance. By default it is always
+   * `true`.
    * @param {string} [params.acceptLanguage] - Prioritize the names returned in the order of the specified languages.
    * Language will default to English.
    * @param {number} [params.limit] - Number of usage records returned. The default value is 30. Maximum value is 200.
@@ -331,6 +333,7 @@ class UsageReportsV4 extends BaseService {
       'accountId',
       'billingmonth',
       'names',
+      'tags',
       'acceptLanguage',
       'limit',
       'start',
@@ -349,6 +352,7 @@ class UsageReportsV4 extends BaseService {
 
     const query = {
       '_names': _params.names,
+      '_tags': _params.tags,
       '_limit': _params.limit,
       '_start': _params.start,
       'resource_group_id': _params.resourceGroupId,
@@ -406,6 +410,8 @@ class UsageReportsV4 extends BaseService {
    * yyyy-mm.
    * @param {boolean} [params.names] - Include the name of every resource, plan, resource instance, organization, and
    * resource group.
+   * @param {boolean} [params.tags] - Include the tags associated with every resource instance. By default it is always
+   * `true`.
    * @param {string} [params.acceptLanguage] - Prioritize the names returned in the order of the specified languages.
    * Language will default to English.
    * @param {number} [params.limit] - Number of usage records returned. The default value is 30. Maximum value is 200.
@@ -428,6 +434,7 @@ class UsageReportsV4 extends BaseService {
       'resourceGroupId',
       'billingmonth',
       'names',
+      'tags',
       'acceptLanguage',
       'limit',
       'start',
@@ -444,6 +451,7 @@ class UsageReportsV4 extends BaseService {
 
     const query = {
       '_names': _params.names,
+      '_tags': _params.tags,
       '_limit': _params.limit,
       '_start': _params.start,
       'resource_instance_id': _params.resourceInstanceId,
@@ -500,6 +508,8 @@ class UsageReportsV4 extends BaseService {
    * yyyy-mm.
    * @param {boolean} [params.names] - Include the name of every resource, plan, resource instance, organization, and
    * resource group.
+   * @param {boolean} [params.tags] - Include the tags associated with every resource instance. By default it is always
+   * `true`.
    * @param {string} [params.acceptLanguage] - Prioritize the names returned in the order of the specified languages.
    * Language will default to English.
    * @param {number} [params.limit] - Number of usage records returned. The default value is 30. Maximum value is 200.
@@ -522,6 +532,7 @@ class UsageReportsV4 extends BaseService {
       'organizationId',
       'billingmonth',
       'names',
+      'tags',
       'acceptLanguage',
       'limit',
       'start',
@@ -538,6 +549,7 @@ class UsageReportsV4 extends BaseService {
 
     const query = {
       '_names': _params.names,
+      '_tags': _params.tags,
       '_limit': _params.limit,
       '_start': _params.start,
       'resource_instance_id': _params.resourceInstanceId,
@@ -1124,6 +1136,8 @@ namespace UsageReportsV4 {
     billingmonth: string;
     /** Include the name of every resource, plan, resource instance, organization, and resource group. */
     names?: boolean;
+    /** Include the tags associated with every resource instance. By default it is always `true`. */
+    tags?: boolean;
     /** Prioritize the names returned in the order of the specified languages. Language will default to English. */
     acceptLanguage?: string;
     /** Number of usage records returned. The default value is 30. Maximum value is 200. */
@@ -1155,6 +1169,8 @@ namespace UsageReportsV4 {
     billingmonth: string;
     /** Include the name of every resource, plan, resource instance, organization, and resource group. */
     names?: boolean;
+    /** Include the tags associated with every resource instance. By default it is always `true`. */
+    tags?: boolean;
     /** Prioritize the names returned in the order of the specified languages. Language will default to English. */
     acceptLanguage?: string;
     /** Number of usage records returned. The default value is 30. Maximum value is 200. */
@@ -1182,6 +1198,8 @@ namespace UsageReportsV4 {
     billingmonth: string;
     /** Include the name of every resource, plan, resource instance, organization, and resource group. */
     names?: boolean;
+    /** Include the tags associated with every resource instance. By default it is always `true`. */
+    tags?: boolean;
     /** Prioritize the names returned in the order of the specified languages. Language will default to English. */
     acceptLanguage?: string;
     /** Number of usage records returned. The default value is 30. Maximum value is 200. */
@@ -1231,7 +1249,7 @@ namespace UsageReportsV4 {
     /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    reportTypes?: CreateReportsSnapshotConfigConstants.ReportTypes | string[];
+    reportTypes?: CreateReportsSnapshotConfigConstants.ReportTypes[] | string[];
     /** A new version of report is created or the existing report version is overwritten with every update. Defaults
      *  to "new".
      */
@@ -1280,7 +1298,7 @@ namespace UsageReportsV4 {
     /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    reportTypes?: UpdateReportsSnapshotConfigConstants.ReportTypes | string[];
+    reportTypes?: UpdateReportsSnapshotConfigConstants.ReportTypes[] | string[];
     /** A new version of report is created or the existing report version is overwritten with every update. */
     versioning?: UpdateReportsSnapshotConfigConstants.Versioning | string;
     headers?: OutgoingHttpHeaders;
@@ -1439,6 +1457,8 @@ namespace UsageReportsV4 {
     resource_instance_name?: string;
     /** The ID of the resource. */
     resource_id: string;
+    /** The catalog ID of the resource. */
+    catalog_id?: string;
     /** The name of the resource. */
     resource_name?: string;
     /** The ID of the resource group. */
@@ -1465,10 +1485,14 @@ namespace UsageReportsV4 {
     currency_code: string;
     /** Is the cost charged to the account. */
     billable: boolean;
+    /** The resource instance id of the parent resource associated with this instance. */
+    parent_resource_instance_id?: string;
     /** The ID of the plan where the instance was provisioned and rated. */
     plan_id: string;
     /** The name of the plan where the instance was provisioned and rated. */
     plan_name?: string;
+    /** The ID of the pricing plan used to rate the usage. */
+    pricing_plan_id?: string;
     /** The month. */
     month: string;
     /** All the resource used in the account. */
@@ -1477,6 +1501,10 @@ namespace UsageReportsV4 {
     pending?: boolean;
     /** The value of the account's currency in USD. */
     currency_rate?: number;
+    /** The user tags associated with a resource instance. */
+    tags?: any[];
+    /** The service tags associated with a resource instance. */
+    service_tags?: any[];
   }
 
   /** The link to the first page of the search query. */
@@ -1589,6 +1617,7 @@ namespace UsageReportsV4 {
     plan_name?: string;
     /** The pricing region for the plan. */
     pricing_region?: string;
+    /** The ID of the pricing plan used to rate the usage. */
     pricing_plan_id?: string;
     /** Indicates if the plan charges are billed to the customer. */
     billable: boolean;
@@ -1608,6 +1637,8 @@ namespace UsageReportsV4 {
   export interface Resource {
     /** The ID of the resource. */
     resource_id: string;
+    /** The catalog ID of the resource. */
+    catalog_id?: string;
     /** The name of the resource. */
     resource_name?: string;
     /** The billable charges for the account. */
@@ -1663,17 +1694,17 @@ namespace UsageReportsV4 {
     /** Account ID for which billing report snapshot is configured. */
     account_id?: string;
     /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
-    state?: string;
+    state?: SnapshotConfigHistoryItem.Constants.State | string;
     /** Type of account. Possible values [enterprise, account]. */
-    account_type?: string;
+    account_type?: SnapshotConfigHistoryItem.Constants.AccountType | string;
     /** Frequency of taking the snapshot of the billing reports. */
-    interval?: string;
+    interval?: SnapshotConfigHistoryItem.Constants.Interval | string;
     /** A new version of report is created or the existing report version is overwritten with every update. */
-    versioning?: string;
+    versioning?: SnapshotConfigHistoryItem.Constants.Versioning | string;
     /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    report_types?: string[];
+    report_types?: SnapshotConfigHistoryItem.Constants.ReportTypes[] | string[];
     /** Compression format of the snapshot report. */
     compression?: string;
     /** Type of content stored in snapshot report. */
@@ -1688,6 +1719,35 @@ namespace UsageReportsV4 {
     cos_location?: string;
     /** The endpoint of the COS instance. */
     cos_endpoint?: string;
+  }
+  export namespace SnapshotConfigHistoryItem {
+    export namespace Constants {
+      /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
+      export enum State {
+        ENABLED = 'enabled',
+        DISABLED = 'disabled',
+      }
+      /** Type of account. Possible values [enterprise, account]. */
+      export enum AccountType {
+        ACCOUNT = 'account',
+        ENTERPRISE = 'enterprise',
+      }
+      /** Frequency of taking the snapshot of the billing reports. */
+      export enum Interval {
+        DAILY = 'daily',
+      }
+      /** A new version of report is created or the existing report version is overwritten with every update. */
+      export enum Versioning {
+        NEW = 'new',
+        OVERWRITE = 'overwrite',
+      }
+      /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. */
+      export enum ReportTypes {
+        ACCOUNT_SUMMARY = 'account_summary',
+        ENTERPRISE_SUMMARY = 'enterprise_summary',
+        ACCOUNT_RESOURCE_INSTANCE_USAGE = 'account_resource_instance_usage',
+      }
+    }
   }
 
   /** List of billing reports snapshots. */
@@ -1720,11 +1780,11 @@ namespace UsageReportsV4 {
     /** Month of captured snapshot. */
     month?: string;
     /** Type of account. Possible values are [enterprise, account]. */
-    account_type?: string;
+    account_type?: SnapshotListSnapshotsItem.Constants.AccountType | string;
     /** Timestamp of snapshot processed. */
     expected_processed_at?: number;
     /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
-    state?: string;
+    state?: SnapshotListSnapshotsItem.Constants.State | string;
     /** Period of billing in snapshot. */
     billing_period?: SnapshotListSnapshotsItemBillingPeriod;
     /** Id of the snapshot captured. */
@@ -1748,6 +1808,20 @@ namespace UsageReportsV4 {
     /** Timestamp at which snapshot is captured. */
     processed_at?: number;
   }
+  export namespace SnapshotListSnapshotsItem {
+    export namespace Constants {
+      /** Type of account. Possible values are [enterprise, account]. */
+      export enum AccountType {
+        ACCOUNT = 'account',
+        ENTERPRISE = 'enterprise',
+      }
+      /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
+      export enum State {
+        ENABLED = 'enabled',
+        DISABLED = 'disabled',
+      }
+    }
+  }
 
   /** Period of billing in snapshot. */
   export interface SnapshotListSnapshotsItemBillingPeriod {
@@ -1762,11 +1836,21 @@ namespace UsageReportsV4 {
     /** The type of billing report stored. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    report_types?: string;
+    report_types?: SnapshotListSnapshotsItemFilesItem.Constants.ReportTypes | string;
     /** Absolute path of the billing report in the COS instance. */
     location?: string;
     /** Account ID for which billing report is captured. */
     account_id?: string;
+  }
+  export namespace SnapshotListSnapshotsItemFilesItem {
+    export namespace Constants {
+      /** The type of billing report stored. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. */
+      export enum ReportTypes {
+        ACCOUNT_SUMMARY = 'account_summary',
+        ENTERPRISE_SUMMARY = 'enterprise_summary',
+        ACCOUNT_RESOURCE_INSTANCE_USAGE = 'account_resource_instance_usage',
+      }
+    }
   }
 
   /** SnapshotListSnapshotsItemReportTypesItem. */
@@ -1774,9 +1858,19 @@ namespace UsageReportsV4 {
     /** The type of billing report of the snapshot. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    type?: string;
+    type?: SnapshotListSnapshotsItemReportTypesItem.Constants.Type | string;
     /** Version of the snapshot. */
     version?: string;
+  }
+  export namespace SnapshotListSnapshotsItemReportTypesItem {
+    export namespace Constants {
+      /** The type of billing report of the snapshot. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. */
+      export enum Type {
+        ACCOUNT_SUMMARY = 'account_summary',
+        ENTERPRISE_SUMMARY = 'enterprise_summary',
+        ACCOUNT_RESOURCE_INSTANCE_USAGE = 'account_resource_instance_usage',
+      }
+    }
   }
 
   /** Billing reports snapshot configuration. */
@@ -1784,17 +1878,17 @@ namespace UsageReportsV4 {
     /** Account ID for which billing report snapshot is configured. */
     account_id?: string;
     /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
-    state?: string;
+    state?: SnapshotConfig.Constants.State | string;
     /** Type of account. Possible values are [enterprise, account]. */
-    account_type?: string;
+    account_type?: SnapshotConfig.Constants.AccountType | string;
     /** Frequency of taking the snapshot of the billing reports. */
-    interval?: string;
+    interval?: SnapshotConfig.Constants.Interval | string;
     /** A new version of report is created or the existing report version is overwritten with every update. */
-    versioning?: string;
+    versioning?: SnapshotConfig.Constants.Versioning | string;
     /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary,
      *  account_resource_instance_usage].
      */
-    report_types?: string[];
+    report_types?: SnapshotConfig.Constants.ReportTypes[] | string[];
     /** Compression format of the snapshot report. */
     compression?: string;
     /** Type of content stored in snapshot report. */
@@ -1825,6 +1919,35 @@ namespace UsageReportsV4 {
     cos_bucket?: string;
     /** Region of the COS instance. */
     cos_location?: string;
+  }
+  export namespace SnapshotConfig {
+    export namespace Constants {
+      /** Status of the billing snapshot configuration. Possible values are [enabled, disabled]. */
+      export enum State {
+        ENABLED = 'enabled',
+        DISABLED = 'disabled',
+      }
+      /** Type of account. Possible values are [enterprise, account]. */
+      export enum AccountType {
+        ACCOUNT = 'account',
+        ENTERPRISE = 'enterprise',
+      }
+      /** Frequency of taking the snapshot of the billing reports. */
+      export enum Interval {
+        DAILY = 'daily',
+      }
+      /** A new version of report is created or the existing report version is overwritten with every update. */
+      export enum Versioning {
+        NEW = 'new',
+        OVERWRITE = 'overwrite',
+      }
+      /** The type of billing reports to take snapshot of. Possible values are [account_summary, enterprise_summary, account_resource_instance_usage]. */
+      export enum ReportTypes {
+        ACCOUNT_SUMMARY = 'account_summary',
+        ENTERPRISE_SUMMARY = 'enterprise_summary',
+        ACCOUNT_RESOURCE_INSTANCE_USAGE = 'account_resource_instance_usage',
+      }
+    }
   }
 
   /** Subscription. */
@@ -1945,7 +2068,7 @@ namespace UsageReportsV4 {
       const response = await this.client.getResourceUsageAccount(this.params);
       const { result } = response;
 
-      let next = null;
+      let next;
       if (result && result.next) {
         if (result.next.href) {
           next = getQueryParam(result.next.href, '_start');
@@ -2029,7 +2152,7 @@ namespace UsageReportsV4 {
       const response = await this.client.getResourceUsageResourceGroup(this.params);
       const { result } = response;
 
-      let next = null;
+      let next;
       if (result && result.next) {
         if (result.next.href) {
           next = getQueryParam(result.next.href, '_start');
@@ -2110,7 +2233,7 @@ namespace UsageReportsV4 {
       const response = await this.client.getResourceUsageOrg(this.params);
       const { result } = response;
 
-      let next = null;
+      let next;
       if (result && result.next) {
         if (result.next.href) {
           next = getQueryParam(result.next.href, '_start');
@@ -2191,7 +2314,7 @@ namespace UsageReportsV4 {
       const response = await this.client.getReportsSnapshot(this.params);
       const { result } = response;
 
-      let next = null;
+      let next;
       if (result && result.next) {
         if (result.next.href) {
           next = getQueryParam(result.next.href, '_start');


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Regeneration of the usage reports service. Mainly intended to add `catalog_id` to `instance_usage` and `resource`.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
Tests:
```
----------------------------|---------|----------|---------|---------|-------------------------------------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                     
----------------------------|---------|----------|---------|---------|-------------------------------------------------------
All files                   |   98.32 |     89.1 |     100 |   98.28 |                                                       
 case-management            |    98.8 |    88.46 |     100 |   98.78 |                                                       
  v1.ts                     |    98.8 |    88.46 |     100 |   98.78 | 129,1246,1269                                         
 catalog-management         |   97.73 |    85.38 |     100 |   97.64 |                                                       
  v1.ts                     |   97.73 |    85.38 |     100 |   97.64 | ...67,11423,11446,11505,11528,11587,11610,11669,11692 
 context-based-restrictions |    98.3 |    92.94 |     100 |   98.29 |                                                       
  v1.ts                     |    98.3 |    92.94 |     100 |   98.29 | 142,499,642,1102                                      
 enterprise-billing-units   |    96.4 |    79.06 |     100 |   96.15 |                                                       
  v1.ts                     |    96.4 |    79.06 |     100 |   96.15 | 185,594,617,676,699                                   
 enterprise-management      |   96.94 |     79.1 |     100 |    96.8 |                                                       
  v1.ts                     |   96.94 |     79.1 |     100 |    96.8 | 209,552,858,1496,1519,1578,1601,1660,1683             
 enterprise-usage-reports   |   95.89 |    78.57 |     100 |   95.58 |                                                       
  v1.ts                     |   95.89 |    78.57 |     100 |   95.58 | 147,388,411                                           
 global-catalog             |     100 |    94.28 |     100 |     100 |                                                       
  v1.ts                     |     100 |    94.28 |     100 |     100 | 88,1166                                               
 global-search              |   98.18 |     87.5 |     100 |   98.14 |                                                       
  v2.ts                     |   98.18 |     87.5 |     100 |   98.14 | 195                                                   
 global-tagging             |   98.59 |    92.98 |     100 |   98.58 |                                                       
  v1.ts                     |   98.59 |    92.98 |     100 |   98.58 | 169,329                                               
 iam-access-groups          |   98.58 |    87.38 |     100 |   98.54 |                                                       
  v2.ts                     |   98.58 |    87.38 |     100 |   98.54 | 3779,3802,3860,3883,3941,3964,4022,4045               
 iam-identity               |   99.15 |    95.17 |     100 |   99.15 |                                                       
  v1.ts                     |   99.15 |    95.17 |     100 |   99.15 | 147,296,722,2597,2912,2974,3661,3975,4047             
 iam-policy-management      |   99.82 |    98.53 |     100 |   99.82 |                                                       
  v1.ts                     |   99.82 |    98.53 |     100 |   99.82 | 653                                                   
 ibm-cloud-shell            |     100 |     92.3 |     100 |     100 |                                                       
  v1.ts                     |     100 |     92.3 |     100 |     100 | 83                                                    
 lib                        |     100 |      100 |     100 |     100 |                                                       
  common.ts                 |     100 |      100 |     100 |     100 |                                                       
 open-service-broker        |     100 |    94.44 |     100 |     100 |                                                       
  v1.ts                     |     100 |    94.44 |     100 |     100 | 83                                                    
 partner-billing-units      |     100 |    95.12 |     100 |     100 |                                                       
  v1.ts                     |     100 |    95.12 |     100 |     100 | 85,229                                                
 partner-usage-reports      |   97.36 |    83.87 |     100 |   97.18 |                                                       
  v1.ts                     |   97.36 |    83.87 |     100 |   97.18 | 413,436                                               
 resource-controller        |   96.79 |    79.41 |     100 |   96.62 |                                                       
  v2.ts                     |   96.79 |    79.41 |     100 |   96.62 | ...,2910,2933,2992,3015,3074,3097,3156,3179,3238,3261 
 resource-manager           |     100 |    93.33 |     100 |     100 |                                                       
  v2.ts                     |     100 |    93.33 |     100 |     100 | 85                                                    
 usage-metering             |     100 |    91.66 |     100 |     100 |                                                       
  v4.ts                     |     100 |    91.66 |     100 |     100 | 87                                                    
 usage-reports              |   97.97 |     90.9 |     100 |   97.88 |                                                       
  v4.ts                     |   97.97 |     90.9 |     100 |   97.88 | 2039,2062,2123,2146,2204,2227,2285,2308               
 user-management            |    98.2 |    82.85 |     100 |   98.14 |                                                       
  v1.ts                     |    98.2 |    82.85 |     100 |   98.14 | 483,1003,1026                                         
----------------------------|---------|----------|---------|---------|-------------------------------------------------------

Test Suites: 22 passed, 22 total
Tests:       1584 passed, 1584 total
Snapshots:   0 total
Time:        5.416 s
Ran all test suites matching /test\/unit\//i.
```
Integration tests:
```
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                                                                                              
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
All files      |   74.44 |    57.14 |   83.78 |   75.64 |                                                                                                                                                                                
 lib           |     100 |      100 |     100 |     100 |                                                                                                                                                                                
  common.ts    |     100 |      100 |     100 |     100 |                                                                                                                                                                                
 usage-reports |    73.8 |    57.14 |   83.56 |      75 |                                                                                                                                                                                
  v4.ts        |    73.8 |    57.14 |   83.56 |      75 | ...,350,449,547,632,710,769,838,897,961,1026,2038-2045,2053,2061-2081,2089-2094,2122-2129,2137,2145-2165,2173-2178,2203-2210,2218,2226-2246,2254-2259,2285,2308,2312,2319-2320 
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        15.992 s, estimated 21 s
Ran all test suites matching /test\/integration\/usage-reports.v4.test.js/i.
```
Examples:
```
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                                                                                              
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
All files      |   72.72 |    55.84 |   82.43 |   74.35 |                                                                                                                                                                                
 lib           |     100 |      100 |     100 |     100 |                                                                                                                                                                                
  common.ts    |     100 |      100 |     100 |     100 |                                                                                                                                                                                
 usage-reports |   72.04 |    55.84 |   82.19 |   73.68 |                                                                                                                                                                                
  v4.ts        |   72.04 |    55.84 |   82.19 |   73.68 | ...47,632,710,769,838,897,961,1026,2038-2045,2053,2061-2081,2089-2094,2122-2129,2137,2145-2165,2173-2178,2203-2210,2218,2226-2246,2254-2259,2285,2308,2312,2319-2320,2335-2340 
---------------|---------|----------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        15.176 s, estimated 17 s
Ran all test suites matching /examples\/usage-reports.v4.test.js/i.
```