### PR TITLE
feat(Catalog Management): get regions routes, support install_type param

### DIFF
--- a/catalog-management/v1.ts
+++ b/catalog-management/v1.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.90.1-64fd3296-20240515-180710
+ * IBM OpenAPI SDK Code Generator Version: 3.92.1-44330004-20240620-143510
  */
 
 /* eslint-disable max-classes-per-file */
@@ -161,6 +161,9 @@ class CatalogManagementV1 extends BaseService {
    * @param {string} [params.rev] - Cloudant revision.
    * @param {boolean} [params.hideIbmCloudCatalog] - Hide the public catalog in this account.
    * @param {Filters} [params.accountFilters] - Filters for account and catalog filters.
+   * @param {string[]} [params.regionFilters] -
+   * @param {string[]} [params.filteredRegions] -
+   * @param {boolean} [params.filterRegions] -
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.Account>>}
    */
@@ -169,7 +172,16 @@ class CatalogManagementV1 extends BaseService {
   ): Promise<CatalogManagementV1.Response<CatalogManagementV1.Account>> {
     const _params = { ...params };
     const _requiredParams = [];
-    const _validParams = ['id', 'rev', 'hideIbmCloudCatalog', 'accountFilters', 'headers'];
+    const _validParams = [
+      'id',
+      'rev',
+      'hideIbmCloudCatalog',
+      'accountFilters',
+      'regionFilters',
+      'filteredRegions',
+      'filterRegions',
+      'headers',
+    ];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -180,6 +192,9 @@ class CatalogManagementV1 extends BaseService {
       '_rev': _params.rev,
       'hide_IBM_cloud_catalog': _params.hideIbmCloudCatalog,
       'account_filters': _params.accountFilters,
+      'region_filters': _params.regionFilters,
+      'filtered_regions': _params.filteredRegions,
+      'filter_regions': _params.filterRegions,
     };
 
     const sdkHeaders = getSdkHeaders(
@@ -1955,6 +1970,7 @@ class CatalogManagementV1 extends BaseService {
    * @param {Flavor} [params.flavor] - Version Flavor Information.  Only supported for Product kind Solution.
    * @param {string} [params.workingDirectory] - Optional - The sub-folder within the specified tgz file that contains
    * the software being onboarded.
+   * @param {string} [params.installType] - The install type of the current software being onboarded.
    * @param {string} [params.zipurl] - URL path to zip location.  If not specified, must provide content in this post
    * body.
    * @param {string} [params.repoType] - The type of repository containing this version.  Valid values are 'public_git'
@@ -1977,6 +1993,7 @@ class CatalogManagementV1 extends BaseService {
       'formatKind',
       'flavor',
       'workingDirectory',
+      'installType',
       'zipurl',
       'repoType',
       'headers',
@@ -1993,6 +2010,7 @@ class CatalogManagementV1 extends BaseService {
       'format_kind': _params.formatKind,
       'flavor': _params.flavor,
       'working_directory': _params.workingDirectory,
+      'install_type': _params.installType,
     };
 
     const query = {
@@ -4030,6 +4048,7 @@ class CatalogManagementV1 extends BaseService {
    * @param {Flavor} [params.flavor] - Version Flavor Information.  Only supported for Product kind Solution.
    * @param {string} [params.workingDirectory] - Optional - The sub-folder within the specified tgz file that contains
    * the software being onboarded.
+   * @param {string} [params.installType] - The install type of the current software being onboarded.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.EmptyObject>>}
    */
@@ -4046,6 +4065,7 @@ class CatalogManagementV1 extends BaseService {
       'formatKind',
       'flavor',
       'workingDirectory',
+      'installType',
       'headers',
     ];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
@@ -4060,6 +4080,7 @@ class CatalogManagementV1 extends BaseService {
       'format_kind': _params.formatKind,
       'flavor': _params.flavor,
       'working_directory': _params.workingDirectory,
+      'install_type': _params.installType,
     };
 
     const path = {
@@ -4186,6 +4207,67 @@ class CatalogManagementV1 extends BaseService {
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
         headers: extend(true, sdkHeaders, {}, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Validates deployment input variables.
+   *
+   * Validates deployment input variables.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.versionLocId - A dotted value of `catalogID`.`versionID`.
+   * @param {string} [params.input1] - A deployment variable to validate.
+   * @param {string} [params.input2] - Another deployment variable to validate.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.VersionInputValidationResponse>>}
+   */
+  public validatesInputs(
+    params: CatalogManagementV1.ValidatesInputsParams
+  ): Promise<CatalogManagementV1.Response<CatalogManagementV1.VersionInputValidationResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['versionLocId'];
+    const _validParams = ['versionLocId', 'input1', 'input2', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'input1': _params.input1,
+      'input2': _params.input2,
+    };
+
+    const path = {
+      'version_loc_id': _params.versionLocId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      CatalogManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'validatesInputs'
+    );
+
+    const parameters = {
+      options: {
+        url: '/versions/{version_loc_id}/validateInputs',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
       }),
     };
 
@@ -7108,6 +7190,121 @@ class CatalogManagementV1 extends BaseService {
 
     return this.createRequest(parameters);
   }
+  /*************************
+   * regions
+   ************************/
+
+  /**
+   * Returns available locations based on supplied filter.
+   *
+   * Returns available locations based on supplied filter.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.filter] - Filter to apply for search.
+   * @param {boolean} [params.getInactive] - Returns inactive locations when true.
+   * @param {number} [params.limit] - The maximum number of results to return.
+   * @param {number} [params.offset] - The number of results to skip before returning values.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>>}
+   */
+  public previewRegions(
+    params?: CatalogManagementV1.PreviewRegionsParams
+  ): Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['filter', 'getInactive', 'limit', 'offset', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'filter': _params.filter,
+      'get_inactive': _params.getInactive,
+      'limit': _params.limit,
+      'offset': _params.offset,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      CatalogManagementV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'previewRegions'
+    );
+
+    const parameters = {
+      options: {
+        url: '/regions',
+        method: 'POST',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Returns available locations based on filter set on the account and supplied filter.
+   *
+   * Returns available locations based on filter set on the account and supplied filter.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.filter] - Filter to apply for search.
+   * @param {boolean} [params.getInactive] - Returns inactive locations when true.
+   * @param {number} [params.limit] - The maximum number of results to return.
+   * @param {number} [params.offset] - The number of results to skip before returning values.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>>}
+   */
+  public getRegions(
+    params?: CatalogManagementV1.GetRegionsParams
+  ): Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['filter', 'getInactive', 'limit', 'offset', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'filter': _params.filter,
+      'get_inactive': _params.getInactive,
+      'limit': _params.limit,
+      'offset': _params.offset,
+    };
+
+    const sdkHeaders = getSdkHeaders(CatalogManagementV1.DEFAULT_SERVICE_NAME, 'v1', 'getRegions');
+
+    const parameters = {
+      options: {
+        url: '/regions',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
 }
 
 /*************************
@@ -7153,6 +7350,9 @@ namespace CatalogManagementV1 {
     hideIbmCloudCatalog?: boolean;
     /** Filters for account and catalog filters. */
     accountFilters?: Filters;
+    regionFilters?: string[];
+    filteredRegions?: string[];
+    filterRegions?: boolean;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -7744,6 +7944,8 @@ namespace CatalogManagementV1 {
     flavor?: Flavor;
     /** Optional - The sub-folder within the specified tgz file that contains the software being onboarded. */
     workingDirectory?: string;
+    /** The install type of the current software being onboarded. */
+    installType?: string;
     /** URL path to zip location.  If not specified, must provide content in this post body. */
     zipurl?: string;
     /** The type of repository containing this version.  Valid values are 'public_git' or 'enterprise_git'. */
@@ -8338,6 +8540,8 @@ namespace CatalogManagementV1 {
     flavor?: Flavor;
     /** Optional - The sub-folder within the specified tgz file that contains the software being onboarded. */
     workingDirectory?: string;
+    /** The install type of the current software being onboarded. */
+    installType?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -8358,6 +8562,17 @@ namespace CatalogManagementV1 {
     type: string;
     /** The version locator id of the version you wish to copy data from. */
     versionLocIdToCopyFrom: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `validatesInputs` operation. */
+  export interface ValidatesInputsParams {
+    /** A dotted value of `catalogID`.`versionID`. */
+    versionLocId: string;
+    /** A deployment variable to validate. */
+    input1?: string;
+    /** Another deployment variable to validate. */
+    input2?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -9174,6 +9389,32 @@ namespace CatalogManagementV1 {
     }
   }
 
+  /** Parameters for the `previewRegions` operation. */
+  export interface PreviewRegionsParams {
+    /** Filter to apply for search. */
+    filter?: string;
+    /** Returns inactive locations when true. */
+    getInactive?: boolean;
+    /** The maximum number of results to return. */
+    limit?: number;
+    /** The number of results to skip before returning values. */
+    offset?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getRegions` operation. */
+  export interface GetRegionsParams {
+    /** Filter to apply for search. */
+    filter?: string;
+    /** Returns inactive locations when true. */
+    getInactive?: boolean;
+    /** The maximum number of results to return. */
+    limit?: number;
+    /** The number of results to skip before returning values. */
+    offset?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /*************************
    * model interfaces
    ************************/
@@ -9240,6 +9481,9 @@ namespace CatalogManagementV1 {
     hide_IBM_cloud_catalog?: boolean;
     /** Filters for account and catalog filters. */
     account_filters?: Filters;
+    region_filters?: string[];
+    filtered_regions?: string[];
+    filter_regions?: boolean;
   }
 
   /** The accumulated filters for an account. This will return the account filters plus a filter for each catalog the user has access to. */
@@ -9250,6 +9494,9 @@ namespace CatalogManagementV1 {
     account_filters?: Filters[];
     /** The filters for all of the accessible catalogs. */
     catalog_filters?: AccumulatedFiltersCatalogFiltersItem[];
+    region_filters?: string[];
+    filtered_regions?: string[];
+    filter_regions?: boolean;
   }
 
   /** AccumulatedFiltersCatalogFiltersItem. */
@@ -10595,6 +10842,64 @@ namespace CatalogManagementV1 {
     four_star_count?: number;
   }
 
+  /** Region information. */
+  export interface Region {
+    id?: string;
+    name?: string;
+    catalog_crn?: string;
+    kind?: string;
+    public?: string;
+    ui?: RegionUi;
+    icon?: string;
+    parent_id?: string;
+    metro_id?: string;
+    country_id?: string;
+    geo_id?: string;
+    authority?: RegionAuthority;
+    tags?: string[];
+    capabilities?: string;
+    created?: string;
+    updated?: string;
+    active?: string;
+    visibility?: JsonObject;
+  }
+
+  /** RegionAuthority. */
+  export interface RegionAuthority {
+    url?: string;
+    crn?: string;
+    provider?: string;
+  }
+
+  /** RegionUi. */
+  export interface RegionUi {
+    _language_?: RegionUiLanguage;
+  }
+
+  /** RegionUiLanguage. */
+  export interface RegionUiLanguage {
+    description?: string;
+    display_name?: string;
+  }
+
+  /** Paginated location search result. */
+  export interface RegionsSearchResult {
+    /** The offset (origin 0) of the first resource in this page of search results. */
+    offset: number;
+    /** The maximum number of resources returned in each page of search results. */
+    limit: number;
+    /** The overall total number of resources in the search result set. */
+    total_count?: number;
+    /** The number of resources returned in this page of search results. */
+    resource_count?: number;
+    /** A URL for retrieving the first page of search results. */
+    first?: string;
+    /** A URL for retrieving the last page of search results. */
+    last?: string;
+    /** Resulting objects. */
+    regions?: Region[];
+  }
+
   /** Render type. */
   export interface RenderType {
     /** ID of the widget type. */
@@ -11100,6 +11405,25 @@ namespace CatalogManagementV1 {
     part_numbers?: string[];
     /** Image repository name. */
     image_repo_name?: string;
+  }
+
+  /** Validate deployment variables. */
+  export interface VersionInputValidationResponse {
+    /** Failure message. */
+    message?: string;
+    /** Response code. */
+    code?: string;
+    /** Transaction ID. */
+    global_transaction_id?: string;
+    /** Transaction ID. */
+    errors?: VersionInputValidationResponseErrorsItem[];
+  }
+
+  /** VersionInputValidationResponseErrorsItem. */
+  export interface VersionInputValidationResponseErrorsItem {
+    message?: string;
+    entity?: string;
+    error_code?: string;
   }
 
   /** Version range information. */

--- a/catalog-management/v1.ts
+++ b/catalog-management/v1.ts
@@ -4225,8 +4225,8 @@ class CatalogManagementV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.VersionInputValidationResponse>>}
    */
-  public validatesInputs(
-    params: CatalogManagementV1.ValidatesInputsParams
+  public validateInputs(
+    params: CatalogManagementV1.ValidateInputsParams
   ): Promise<CatalogManagementV1.Response<CatalogManagementV1.VersionInputValidationResponse>> {
     const _params = { ...params };
     const _requiredParams = ['versionLocId'];
@@ -4248,7 +4248,7 @@ class CatalogManagementV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       CatalogManagementV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'validatesInputs'
+      'validateInputs'
     );
 
     const parameters = {
@@ -7265,8 +7265,8 @@ class CatalogManagementV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>>}
    */
-  public getRegions(
-    params?: CatalogManagementV1.GetRegionsParams
+  public listRegions(
+    params?: CatalogManagementV1.ListRegionsParams
   ): Promise<CatalogManagementV1.Response<CatalogManagementV1.RegionsSearchResult>> {
     const _params = { ...params };
     const _requiredParams = [];
@@ -7283,7 +7283,7 @@ class CatalogManagementV1 extends BaseService {
       'offset': _params.offset,
     };
 
-    const sdkHeaders = getSdkHeaders(CatalogManagementV1.DEFAULT_SERVICE_NAME, 'v1', 'getRegions');
+    const sdkHeaders = getSdkHeaders(CatalogManagementV1.DEFAULT_SERVICE_NAME, 'v1', 'listRegions');
 
     const parameters = {
       options: {
@@ -8565,8 +8565,8 @@ namespace CatalogManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `validatesInputs` operation. */
-  export interface ValidatesInputsParams {
+  /** Parameters for the `validateInputs` operation. */
+  export interface ValidateInputsParams {
     /** A dotted value of `catalogID`.`versionID`. */
     versionLocId: string;
     /** A deployment variable to validate. */
@@ -9402,8 +9402,8 @@ namespace CatalogManagementV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `getRegions` operation. */
-  export interface GetRegionsParams {
+  /** Parameters for the `listRegions` operation. */
+  export interface ListRegionsParams {
     /** Filter to apply for search. */
     filter?: string;
     /** Returns inactive locations when true. */

--- a/examples/catalog-management.v1.test.js
+++ b/examples/catalog-management.v1.test.js
@@ -1396,6 +1396,62 @@ describe('CatalogManagementV1', () => {
     // end-list_objects
   });
 
+  test('getRegions request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('getRegions() result:');
+    // begin-get_regions
+
+    const params = {
+      filter: '',
+    };
+
+    let res;
+    try {
+      res = await catalogManagementService.getRegions(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-get_regions
+  });
+
+  test('previewRegions request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('previewRegions() result:');
+    // begin-preview_regions
+
+    const params = {
+      filter: '',
+    };
+
+    let res;
+    try {
+      res = await catalogManagementService.previewRegions(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-preview_regions
+  });
+
   test('deleteObject request example', async () => {
     consoleLogMock.mockImplementation((output) => {
       originalLog(output);

--- a/examples/catalog-management.v1.test.js
+++ b/examples/catalog-management.v1.test.js
@@ -328,7 +328,7 @@ describe('CatalogManagementV1', () => {
     versionRevLink = responseBody.kinds[0].versions[0]._rev;
   });
 
-  test('validatesInputs request example', async () => {
+  test('validateInputs request example', async () => {
     consoleLogMock.mockImplementation((output) => {
       originalLog(output);
     });
@@ -338,8 +338,8 @@ describe('CatalogManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('validatesInputs() result:');
-    // begin-import_offering_version
+    originalLog('validateInputs() result:');
+    // begin-validate_inputs
 
     const params = {
       versionLocId: versionLocatorLink,
@@ -349,13 +349,13 @@ describe('CatalogManagementV1', () => {
 
     let res;
     try {
-      res = await catalogManagementService.validatesInputs(params);
+      res = await catalogManagementService.validateInputs(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err);
     }
 
-    // end-import_offering_version
+    // end-validate_inputs
   });
 
   // Set allow publish offering
@@ -1434,7 +1434,7 @@ describe('CatalogManagementV1', () => {
     // end-list_objects
   });
 
-  test('getRegions request example', async () => {
+  test('listRegions request example', async () => {
     consoleLogMock.mockImplementation((output) => {
       originalLog(output);
     });
@@ -1444,8 +1444,8 @@ describe('CatalogManagementV1', () => {
       expect(true).toBeFalsy();
     });
 
-    originalLog('getRegions() result:');
-    // begin-get_regions
+    originalLog('listRegions() result:');
+    // begin-list_regions
 
     const params = {
       filter: '',
@@ -1453,13 +1453,13 @@ describe('CatalogManagementV1', () => {
 
     let res;
     try {
-      res = await catalogManagementService.getRegions(params);
+      res = await catalogManagementService.listRegions(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err);
     }
 
-    // end-get_regions
+    // end-list_regions
   });
 
   test('previewRegions request example', async () => {

--- a/examples/catalog-management.v1.test.js
+++ b/examples/catalog-management.v1.test.js
@@ -149,9 +149,17 @@ describe('CatalogManagementV1', () => {
     originalLog('updateCatalogAccount() result:');
     // begin-update_catalog_account
 
+    const params = {
+      rev: accountRevLink,
+      accountFilters: {
+        include_all: true,
+        id_filters: {},
+      }
+    }
+
     let res;
     try {
-      res = await catalogManagementService.updateCatalogAccount({ rev: accountRevLink });
+      res = await catalogManagementService.updateCatalogAccount(params);
       console.log(JSON.stringify(res.result, null, 2));
     } catch (err) {
       console.warn(err);
@@ -318,6 +326,36 @@ describe('CatalogManagementV1', () => {
     versionLocatorLink = responseBody.kinds[0].versions[0].version_locator;
     versionIdLink = responseBody.kinds[0].versions[0].version_locator;
     versionRevLink = responseBody.kinds[0].versions[0]._rev;
+  });
+
+  test('validatesInputs request example', async () => {
+    consoleLogMock.mockImplementation((output) => {
+      originalLog(output);
+    });
+    consoleWarnMock.mockImplementation((output) => {
+      // if an error occurs, display the message and then fail the test
+      originalWarn(output);
+      expect(true).toBeFalsy();
+    });
+
+    originalLog('validatesInputs() result:');
+    // begin-import_offering_version
+
+    const params = {
+      versionLocId: versionLocatorLink,
+      input1: 'name',
+      input2: '',
+    };
+
+    let res;
+    try {
+      res = await catalogManagementService.validatesInputs(params);
+      console.log(JSON.stringify(res.result, null, 2));
+    } catch (err) {
+      console.warn(err);
+    }
+
+    // end-import_offering_version
   });
 
   // Set allow publish offering

--- a/test/integration/catalog-management.v1.test.js
+++ b/test/integration/catalog-management.v1.test.js
@@ -157,7 +157,7 @@ describe('CatalogManagementV1_integration', () => {
     offeringRevLink = res.result._rev;
   });
 
-  test('validatesInputs()', async () => {
+  test('validateInputs()', async () => {
     // Request models needed by this operation.
 
     const params = {
@@ -166,7 +166,7 @@ describe('CatalogManagementV1_integration', () => {
       input2: '',
     };
 
-    const res = await catalogManagementService.validatesInputs(params);
+    const res = await catalogManagementService.validateInputs(params);
     expect(res).toBeDefined();
     expect(res.status).toBe(200);
     expect(res.result).toBeDefined();
@@ -814,12 +814,12 @@ describe('CatalogManagementV1_integration', () => {
     console.log(`Retrieved a total of ${allResults.length} items(s) with pagination.`);
   });
 
-  test('getRegions()', async () => {
+  test('listRegions()', async () => {
     const params = {
       filter: '',
     };
 
-    const res = await catalogManagementService.getRegions(params);
+    const res = await catalogManagementService.listRegions(params);
     expect(res).toBeDefined();
     expect(res.status).toBe(200);
     expect(res.result).toBeDefined();

--- a/test/integration/catalog-management.v1.test.js
+++ b/test/integration/catalog-management.v1.test.js
@@ -157,6 +157,21 @@ describe('CatalogManagementV1_integration', () => {
     offeringRevLink = res.result._rev;
   });
 
+  test('validatesInputs()', async () => {
+    // Request models needed by this operation.
+
+    const params = {
+      versionLocId: versionLocatorLink,
+      input1: 'name',
+      input2: '',
+    };
+
+    const res = await catalogManagementService.validatesInputs(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(res.result).toBeDefined();
+  });
+
   // Set allow publish offering
   test('setAllowPublishOffering request example', async () => {
     const headers = {

--- a/test/integration/catalog-management.v1.test.js
+++ b/test/integration/catalog-management.v1.test.js
@@ -799,6 +799,28 @@ describe('CatalogManagementV1_integration', () => {
     console.log(`Retrieved a total of ${allResults.length} items(s) with pagination.`);
   });
 
+  test('getRegions()', async () => {
+    const params = {
+      filter: '',
+    };
+
+    const res = await catalogManagementService.getRegions(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(res.result).toBeDefined();
+  });
+
+  test('previewRegions()', async () => {
+    const params = {
+      filter: '',
+    };
+
+    const res = await catalogManagementService.previewRegions(params);
+    expect(res).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(res.result).toBeDefined();
+  });
+
   test('deleteVersion()', async () => {
     const params = {
       versionLocId: versionLocatorLink,
@@ -808,6 +830,27 @@ describe('CatalogManagementV1_integration', () => {
     expect(res).toBeDefined();
     expect(res.status).toBe(200);
     expect(res.result).toBeDefined();
+  });
+
+  // unset pc managed on this offering so we can delete it
+  test('setAllowPublishOffering unset pc_managed request example', async () => {
+    const headers = {
+      'X-Approver-Token': approverToken,
+    };
+
+    const response = await fetch(
+      `https://cm.globalcatalog.test.cloud.ibm.com/api/v1-beta/catalogs/${catalogIdLink}/offerings/${offeringIdLink}/publish/pc_managed/false`,
+      {
+        method: 'POST',
+        headers: {
+          ...headers,
+          'Authorization': `bearer ${token}`,
+        },
+      }
+    );
+    const res = await response.json();
+    expect(res).toBeDefined();
+    expect(response.status).toBe(200);
   });
 
   test('deleteOffering()', async () => {

--- a/test/unit/catalog-management.v1.test.js
+++ b/test/unit/catalog-management.v1.test.js
@@ -7626,23 +7626,23 @@ describe('CatalogManagementV1', () => {
     });
   });
 
-  describe('validatesInputs', () => {
+  describe('validateInputs', () => {
     describe('positive tests', () => {
-      function __validatesInputsTest() {
-        // Construct the params object for operation validatesInputs
+      function __validateInputsTest() {
+        // Construct the params object for operation validateInputs
         const versionLocId = 'testString';
         const input1 = 'testString';
         const input2 = 'testString';
-        const validatesInputsParams = {
+        const validateInputsParams = {
           versionLocId,
           input1,
           input2,
         };
 
-        const validatesInputsResult = catalogManagementService.validatesInputs(validatesInputsParams);
+        const validateInputsResult = catalogManagementService.validateInputs(validateInputsParams);
 
         // all methods should return a Promise
-        expectToBePromise(validatesInputsResult);
+        expectToBePromise(validateInputsResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -7660,17 +7660,17 @@ describe('CatalogManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __validatesInputsTest();
+        __validateInputsTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         catalogManagementService.enableRetries();
-        __validatesInputsTest();
+        __validateInputsTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         catalogManagementService.disableRetries();
-        __validatesInputsTest();
+        __validateInputsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -7678,7 +7678,7 @@ describe('CatalogManagementV1', () => {
         const versionLocId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const validatesInputsParams = {
+        const validateInputsParams = {
           versionLocId,
           headers: {
             Accept: userAccept,
@@ -7686,7 +7686,7 @@ describe('CatalogManagementV1', () => {
           },
         };
 
-        catalogManagementService.validatesInputs(validatesInputsParams);
+        catalogManagementService.validateInputs(validateInputsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -7695,7 +7695,7 @@ describe('CatalogManagementV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await catalogManagementService.validatesInputs({});
+          await catalogManagementService.validateInputs({});
         } catch (e) {
           err = e;
         }
@@ -7706,7 +7706,7 @@ describe('CatalogManagementV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await catalogManagementService.validatesInputs();
+          await catalogManagementService.validateInputs();
         } catch (e) {
           err = e;
         }
@@ -12591,25 +12591,25 @@ describe('CatalogManagementV1', () => {
     });
   });
 
-  describe('getRegions', () => {
+  describe('listRegions', () => {
     describe('positive tests', () => {
-      function __getRegionsTest() {
-        // Construct the params object for operation getRegions
+      function __listRegionsTest() {
+        // Construct the params object for operation listRegions
         const filter = 'testString';
         const getInactive = true;
         const limit = 100;
         const offset = 0;
-        const getRegionsParams = {
+        const listRegionsParams = {
           filter,
           getInactive,
           limit,
           offset,
         };
 
-        const getRegionsResult = catalogManagementService.getRegions(getRegionsParams);
+        const listRegionsResult = catalogManagementService.listRegions(listRegionsParams);
 
         // all methods should return a Promise
-        expectToBePromise(getRegionsResult);
+        expectToBePromise(listRegionsResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -12628,37 +12628,37 @@ describe('CatalogManagementV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __getRegionsTest();
+        __listRegionsTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         catalogManagementService.enableRetries();
-        __getRegionsTest();
+        __listRegionsTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         catalogManagementService.disableRetries();
-        __getRegionsTest();
+        __listRegionsTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const getRegionsParams = {
+        const listRegionsParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        catalogManagementService.getRegions(getRegionsParams);
+        catalogManagementService.listRegions(listRegionsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
       test('should not have any problems when no parameters are passed in', () => {
         // invoke the method with no parameters
-        catalogManagementService.getRegions({});
+        catalogManagementService.listRegions({});
         checkForSuccessfulExecution(createRequestMock);
       });
     });

--- a/test/unit/catalog-management.v1.test.js
+++ b/test/unit/catalog-management.v1.test.js
@@ -215,11 +215,17 @@ describe('CatalogManagementV1', () => {
         const rev = 'testString';
         const hideIbmCloudCatalog = true;
         const accountFilters = filtersModel;
+        const regionFilters = ['testString'];
+        const filteredRegions = ['testString'];
+        const filterRegions = true;
         const updateCatalogAccountParams = {
           id,
           rev,
           hideIbmCloudCatalog,
           accountFilters,
+          regionFilters,
+          filteredRegions,
+          filterRegions,
         };
 
         const updateCatalogAccountResult = catalogManagementService.updateCatalogAccount(updateCatalogAccountParams);
@@ -240,6 +246,9 @@ describe('CatalogManagementV1', () => {
         expect(mockRequestOptions.body._rev).toEqual(rev);
         expect(mockRequestOptions.body.hide_IBM_cloud_catalog).toEqual(hideIbmCloudCatalog);
         expect(mockRequestOptions.body.account_filters).toEqual(accountFilters);
+        expect(mockRequestOptions.body.region_filters).toEqual(regionFilters);
+        expect(mockRequestOptions.body.filtered_regions).toEqual(filteredRegions);
+        expect(mockRequestOptions.body.filter_regions).toEqual(filterRegions);
       }
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
@@ -3642,6 +3651,7 @@ describe('CatalogManagementV1', () => {
         const formatKind = 'testString';
         const flavor = flavorModel;
         const workingDirectory = 'testString';
+        const installType = 'testString';
         const zipurl = 'testString';
         const repoType = 'testString';
         const reloadOfferingParams = {
@@ -3654,6 +3664,7 @@ describe('CatalogManagementV1', () => {
           formatKind,
           flavor,
           workingDirectory,
+          installType,
           zipurl,
           repoType,
         };
@@ -3678,6 +3689,7 @@ describe('CatalogManagementV1', () => {
         expect(mockRequestOptions.body.format_kind).toEqual(formatKind);
         expect(mockRequestOptions.body.flavor).toEqual(flavor);
         expect(mockRequestOptions.body.working_directory).toEqual(workingDirectory);
+        expect(mockRequestOptions.body.install_type).toEqual(installType);
         expect(mockRequestOptions.qs.targetVersion).toEqual(targetVersion);
         expect(mockRequestOptions.qs.zipurl).toEqual(zipurl);
         expect(mockRequestOptions.qs.repoType).toEqual(repoType);
@@ -7342,6 +7354,7 @@ describe('CatalogManagementV1', () => {
         const formatKind = 'testString';
         const flavor = flavorModel;
         const workingDirectory = 'testString';
+        const installType = 'testString';
         const copyVersionParams = {
           versionLocId,
           tags,
@@ -7350,6 +7363,7 @@ describe('CatalogManagementV1', () => {
           formatKind,
           flavor,
           workingDirectory,
+          installType,
         };
 
         const copyVersionResult = catalogManagementService.copyVersion(copyVersionParams);
@@ -7372,6 +7386,7 @@ describe('CatalogManagementV1', () => {
         expect(mockRequestOptions.body.format_kind).toEqual(formatKind);
         expect(mockRequestOptions.body.flavor).toEqual(flavor);
         expect(mockRequestOptions.body.working_directory).toEqual(workingDirectory);
+        expect(mockRequestOptions.body.install_type).toEqual(installType);
         expect(mockRequestOptions.path.version_loc_id).toEqual(versionLocId);
       }
 
@@ -7602,6 +7617,96 @@ describe('CatalogManagementV1', () => {
         let err;
         try {
           await catalogManagementService.copyFromPreviousVersion();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('validatesInputs', () => {
+    describe('positive tests', () => {
+      function __validatesInputsTest() {
+        // Construct the params object for operation validatesInputs
+        const versionLocId = 'testString';
+        const input1 = 'testString';
+        const input2 = 'testString';
+        const validatesInputsParams = {
+          versionLocId,
+          input1,
+          input2,
+        };
+
+        const validatesInputsResult = catalogManagementService.validatesInputs(validatesInputsParams);
+
+        // all methods should return a Promise
+        expectToBePromise(validatesInputsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/versions/{version_loc_id}/validateInputs', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.input1).toEqual(input1);
+        expect(mockRequestOptions.body.input2).toEqual(input2);
+        expect(mockRequestOptions.path.version_loc_id).toEqual(versionLocId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __validatesInputsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.enableRetries();
+        __validatesInputsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.disableRetries();
+        __validatesInputsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const versionLocId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const validatesInputsParams = {
+          versionLocId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        catalogManagementService.validatesInputs(validatesInputsParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await catalogManagementService.validatesInputs({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await catalogManagementService.validatesInputs();
         } catch (e) {
           err = e;
         }
@@ -12409,6 +12514,152 @@ describe('CatalogManagementV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('previewRegions', () => {
+    describe('positive tests', () => {
+      function __previewRegionsTest() {
+        // Construct the params object for operation previewRegions
+        const filter = 'testString';
+        const getInactive = true;
+        const limit = 100;
+        const offset = 0;
+        const previewRegionsParams = {
+          filter,
+          getInactive,
+          limit,
+          offset,
+        };
+
+        const previewRegionsResult = catalogManagementService.previewRegions(previewRegionsParams);
+
+        // all methods should return a Promise
+        expectToBePromise(previewRegionsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/regions', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.filter).toEqual(filter);
+        expect(mockRequestOptions.qs.get_inactive).toEqual(getInactive);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __previewRegionsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.enableRetries();
+        __previewRegionsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.disableRetries();
+        __previewRegionsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const previewRegionsParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        catalogManagementService.previewRegions(previewRegionsParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        catalogManagementService.previewRegions({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+  });
+
+  describe('getRegions', () => {
+    describe('positive tests', () => {
+      function __getRegionsTest() {
+        // Construct the params object for operation getRegions
+        const filter = 'testString';
+        const getInactive = true;
+        const limit = 100;
+        const offset = 0;
+        const getRegionsParams = {
+          filter,
+          getInactive,
+          limit,
+          offset,
+        };
+
+        const getRegionsResult = catalogManagementService.getRegions(getRegionsParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getRegionsResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/regions', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.filter).toEqual(filter);
+        expect(mockRequestOptions.qs.get_inactive).toEqual(getInactive);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getRegionsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.enableRetries();
+        __getRegionsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        catalogManagementService.disableRetries();
+        __getRegionsTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getRegionsParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        catalogManagementService.getRegions(getRegionsParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        catalogManagementService.getRegions({});
+        checkForSuccessfulExecution(createRequestMock);
       });
     });
   });


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Regenerating after some small API changes.  Need to support install_type param on reloadOffering function for a user.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->
Only adding new params and routes.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Test results
Integration tests
```
Test Suites: 20 skipped, 1 passed, 1 of 21 total
Tests:       406 skipped, 51 passed, 457 total
Snapshots:   0 total
Time:        31.572 s
Ran all test suites matching /test\/integration\//i.
```

Example tests
```
Test Suites: 1 passed, 1 total
Tests:       47 passed, 47 total
Snapshots:   0 total
Time:        27.183 s
Ran all test suites matching /examples\/catalog-management.v1.test.js/i.
```