### PR TITLE
fix(build): remove comments from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,20 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es5",
+    "module": "commonjs",
     "lib": [
       "es5",
       "es2015",
       "dom",
       "scripthost"
     ],
-
-    /* Build source files into a folder called `dist` to maintain clean directories, free of ts-generated files */
     "outDir": "./dist",
-
-    /* Specify library files to be included in the compilation:  */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
-
-    /* Strict Type-Checking Options */
-    "alwaysStrict": true,                   /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Module Resolution Options */
-    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "types": ["node"], /* Type declaration files to be included in compilation. */
+    "declaration": true,
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "moduleResolution": "node",
+    "types": [
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
This commit removes comments from the tsconfig.json file in hopes that this will fix a problem seen in the most recent main branch build after changes to the .releaserc file were merged into main.