### PR TITLE
fix(Global Catalog): remove bad metadata fields

### DIFF
--- a/global-catalog/v1.ts
+++ b/global-catalog/v1.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.104.0-b4a47c49-20250418-184351
+ * IBM OpenAPI SDK Code Generator Version: 3.106.0-09823488-20250707-071701
  */
 
 import * as extend from 'extend';
@@ -1981,14 +1981,6 @@ namespace GlobalCatalogV1 {
     cf_guid?: JsonObject;
     /** Cloud resource name identifying the environment containing this service. */
     crn_mask?: string;
-    /** Service specific parameters needed to configure the service on provisioning. Each parameter must be a map
-     *  with string keys containing a 'name' key.
-     */
-    parameters?: JsonObject;
-    /** Deprecated: An extended set of metadata fields that pertain to user-defined services. */
-    user_defined_service?: JsonObject;
-    /** Deprecated: A property-bag like extension to service metadata. */
-    extension?: JsonObject;
     /** Deprecated: Boolean flag indicating if this service only offers paid pricing plans rather than the default
      *  paygo.
      */

--- a/test/unit/global-catalog.v1.test.js
+++ b/test/unit/global-catalog.v1.test.js
@@ -249,9 +249,6 @@ describe('GlobalCatalogV1', () => {
         service_key_supported: true,
         cf_guid: { 'key1': 'testString' },
         crn_mask: 'testString',
-        parameters: { anyKey: 'anyValue' },
-        user_defined_service: { anyKey: 'anyValue' },
-        extension: { anyKey: 'anyValue' },
         paid_only: true,
         custom_create_page_hybrid_enabled: true,
       };
@@ -739,9 +736,6 @@ describe('GlobalCatalogV1', () => {
         service_key_supported: true,
         cf_guid: { 'key1': 'testString' },
         crn_mask: 'testString',
-        parameters: { anyKey: 'anyValue' },
-        user_defined_service: { anyKey: 'anyValue' },
-        extension: { anyKey: 'anyValue' },
         paid_only: true,
         custom_create_page_hybrid_enabled: true,
       };


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
These fields use an `interface{}` type in golang and support being an array or an object, so cannot be supported by the SDK or the `oneOf` definitions in swagger. These are deeply nested metadata fields that aren't necessary in the SDK, and were only just recently added but caused some errors because of invalid types. So we just want to remove them.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->
Just removing unnecessary fields.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->

integration:

```
Test Suites: 19 skipped, 1 passed, 1 of 20 total
Tests:       465 skipped, 27 passed, 492 total
Snapshots:   0 total
Time:        18.486 s, estimated 22 s
Ran all test suites matching /test\/integration\/|test\/integration\/global-catalog.v1.test.js/i.
```

example:

```
Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        4.069 s, estimated 6 s
Ran all test suites matching /examples\/global-catalog.v1.test.js/i.
```