### PR TITLE
fix(build): bump dependencies to avoid CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/node": "^18.19.80",
         "extend": "3.0.2",
-        "ibm-cloud-sdk-core": "^5.4.1"
+        "ibm-cloud-sdk-core": "^5.4.2"
       },
       "devDependencies": {
         "@ibm-cloud/sdk-test-utilities": "^1.0.0",
@@ -2685,13 +2685,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -5714,15 +5714,15 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.1.tgz",
-      "integrity": "sha512-kGh1KlkFHFsJANWiGTJZ5PNoL4bZHAGprAa/uSFvLpJdKUEOH+xUAUYcLMTH71jtgy9Wl2ePDjaLWiWe80uGiA==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.2.tgz",
+      "integrity": "sha512-5VFkKYU/vSIWFJTVt392XEdPmiEwUJqhxjn1MRO3lfELyU2FB+yYi8brbmXUgq+D1acHR1fpS7tIJ6IlnrR9Cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "^1.8.2",
+        "axios": "^1.11.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@types/node": "^18.19.80",
     "extend": "3.0.2",
-    "ibm-cloud-sdk-core": "^5.4.1"
+    "ibm-cloud-sdk-core": "^5.4.2"
   },
   "devDependencies": {
     "@ibm-cloud/sdk-test-utilities": "^1.0.0",


### PR DESCRIPTION
Bump sdk-core to 5.4.2 and axios to 1.11.0 to avoid vulnerabilities.